### PR TITLE
Collections Endpoints 

### DIFF
--- a/src/main/java/com/github/redouane59/twitter/ITwitterClientV1.java
+++ b/src/main/java/com/github/redouane59/twitter/ITwitterClientV1.java
@@ -1,6 +1,9 @@
 package com.github.redouane59.twitter;
 
 import com.github.redouane59.RelationType;
+import com.github.redouane59.twitter.dto.collections.CollectionsResponse;
+import com.github.redouane59.twitter.dto.collections.CollectionsResponse.Response.Position;
+import com.github.redouane59.twitter.dto.collections.TimeLineOrder;
 import com.github.redouane59.twitter.dto.others.RateLimitStatus;
 import com.github.redouane59.twitter.dto.others.RequestToken;
 import com.github.redouane59.twitter.dto.tweet.MediaCategory;
@@ -185,5 +188,50 @@ public interface ITwitterClientV1 {
    * Upload a media calling https://upload.twitter.com/1.1/media/upload.json
    */
   UploadMediaResponse uploadMedia(File media, MediaCategory mediaCategory);
+
+  /**
+   * Creates a collection of tweets. See https://api.twitter.com/1.1/collections/create.json
+   *
+   * @param name required. Name of the collection - truncated by twitter to 25 characters
+   * @param description optional. Description for collection - truncated by twitter to 160 characters
+   * @param collectionUrl optional. A fully-qualified URL to associate with this collection.
+   * @param timeLineOrder optional. Order Tweets chronologically or in the order they are added to a Collection. Defaults to order tweets added to
+   * collection ({@link TimeLineOrder#CURATION_ORDER})
+   * @return CollectionCreateResponse - response from https://api.twitter.com/1.1/collections/create.json - including the collection identifier
+   * 'timeline_id'
+   */
+  CollectionsResponse collectionsCreate(String name, String description, String collectionUrl, TimeLineOrder timeLineOrder);
+
+  /**
+   * Adds tweets to an existing collection. See https://api.twitter.com/1.1/collections/create.json
+   *
+   * @param collectionId the id of the collection to add tweets to
+   * @param tweetIds Tweets to be added to collection.  > 100 will result in multiple calls to the collections/create.json endpoint
+   * @return an object indicating either no errors or listing the errors for each tweet that was rejected
+   */
+  CollectionsResponse collectionsCurate(String collectionId, List<String> tweetIds);
+
+  /**
+   * Gets tweets from an existing collection. See https://api.twitter.com/1.1/collections/entries.json
+   *
+   * To retrieve Tweets further back in time, use the value of min_position found in the current response as the max_position parameter in the
+   * next call to this endpoint.
+   *
+   * @param collectionId the id of the collection to retrieve tweets from
+   * @param count optional. Specifies the maximum number of results to include in the response 1-200.  {@link Position#getWasTruncated()} will
+   * indicate if more tweets in collection
+   * @param maxPosition optional. Returns results with a position value less than or equal to the specified position (tweetId in collection)
+   * @param minPosition optional. Returns results with a position greater than the specified position (tweetId in collection)
+   */
+  CollectionsResponse collectionsEntries(String collectionId, int count, String maxPosition, String minPosition);
+
+  /**
+   * Destroys a collection by id. See https://api.twitter.com/1.1/collections/destroy.json
+   *
+   * @param collectionId the identifier of the collection to destroy
+   * @return {@link CollectionsResponse#isDestroyed()}
+   */
+  CollectionsResponse collectionsDestroy(String collectionId);
+
 }
 

--- a/src/main/java/com/github/redouane59/twitter/dto/collections/CollectionsResponse.java
+++ b/src/main/java/com/github/redouane59/twitter/dto/collections/CollectionsResponse.java
@@ -1,0 +1,231 @@
+package com.github.redouane59.twitter.dto.collections;
+
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.redouane59.twitter.dto.tweet.TweetV1;
+import com.github.redouane59.twitter.dto.user.UserV1;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * See Collections <a href ="https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/overview/response_structures"> Response
+ * Structures</a>
+ */
+@Getter
+@Setter
+public class CollectionsResponse {
+
+  /**
+   * Populated if  destroy collection is called - https://api.twitter.com/1.1/collections/destroy.json
+   */
+  private boolean destroyed;
+
+  @JsonProperty("response")
+  private Response response;
+
+  @JsonProperty("objects")
+  private Objects objects;
+
+  public boolean hasErrors() {
+    return response != null && response.errors != null && !response.errors.isEmpty();
+  }
+
+  @Getter
+  @Setter
+  public static class Response {
+
+    /**
+     * The timeline_id is the collection identifier.
+     */
+    @JsonProperty("timeline_id")
+    private String timeLineId;
+
+    /**
+     * Errors reported from call to curate a collection - empty list indicates success Note: response to create collection will not populate this
+     */
+    private List<Error> errors = new ArrayList<>();
+
+    private List<TimelineTweet> timeline = new ArrayList<>();
+
+
+    private Position position;
+
+
+    @Getter
+    @Setter
+    public static class Position {
+
+      @JsonProperty("max_position")
+      private String maxPosition;
+
+      @JsonProperty("min_position")
+      private String minPosition;
+
+      /**
+       * was_truncated indicates whether additional Tweets exist in the collection outside of the range of the current request
+       */
+      @JsonProperty("was_truncated")
+      private Boolean wasTruncated;
+    }
+
+
+    @Getter
+    @Setter
+    public static class TimelineTweet {
+
+      private Value tweet;
+
+      @JsonProperty("feature_context")
+      private String featureContext;
+
+
+      @Getter
+      @Setter
+      public static class Value {
+
+        private String id;
+
+        @JsonProperty("sort_index")
+        private String sortIndex;
+
+      }
+    }
+
+    @Getter
+    @Setter
+    public static class Error {
+
+      /**
+       * Reason the tweet was rejected when added to collection
+       */
+      private String reason;
+      /**
+       * The change that was requested i.e. 'add' tweet to collection
+       */
+      private Change change;
+
+      @Getter
+      @Setter
+      public static class Change {
+
+        @JsonProperty("op")
+        private String operation;
+        @JsonProperty("tweet_id")
+        private String tweetId;
+
+      }
+
+    }
+
+  }
+
+  @Getter
+  @Setter
+  public static class Objects {
+
+    private Tweets    tweets;
+    private Users     users;
+    private Timelines timelines;
+
+
+    @Getter
+    @Setter
+    public static class Tweets {
+
+      // TweetId Mapped to the tweet itself
+      private Map<String, TweetV1> tweetDetails = new HashMap<>();
+
+      @JsonAnyGetter
+      public Map<String, TweetV1> getTweetDetails() {
+        return tweetDetails;
+      }
+
+      @JsonAnySetter
+      public void setTweetDetails(String name, TweetV1 value) {
+        this.tweetDetails.put(name, value);
+      }
+
+      public List<TweetV1> get() {
+        return new ArrayList<>(tweetDetails.values());
+      }
+    }
+
+    @Getter
+    @Setter
+    public static class Users {
+
+      // UserId Mapped to the tweet itself
+      private Map<String, UserV1> userDetails = new HashMap<>();
+
+      @JsonAnyGetter
+      public Map<String, UserV1> getUserDetails() {
+        return userDetails;
+      }
+
+      @JsonAnySetter
+      public void setUserDetails(String name, UserV1 value) {
+        this.userDetails.put(name, value);
+      }
+
+      public List<UserV1> get() {
+        return new ArrayList<>(userDetails.values());
+      }
+
+
+    }
+
+    @Getter
+    @Setter
+    public static class Timelines {
+
+      // Timeline id Mapped to the timeline itself
+      private Map<String, Timeline> timelineDetails = new HashMap<>();
+
+      @JsonAnyGetter
+      public Map<String, Timeline> getTimelineDetailsDetails() {
+        return timelineDetails;
+      }
+
+      @JsonAnySetter
+      public void setTimelineDetails(String name, Timeline value) {
+        this.timelineDetails.put(name, value);
+      }
+
+      public List<Timeline> get() {
+        return new ArrayList<>(timelineDetails.values());
+      }
+
+      @Getter
+      @Setter
+      public static class Timeline {
+
+        @JsonProperty("name")
+        private String name;
+        @JsonProperty("user_id")
+        private String userId;
+        @JsonProperty("collection_url")
+        private String collectionUrl;
+        @JsonProperty("custom_timeline_url")
+        private String collectionTimelineUrl;
+        @JsonProperty("description")
+        private String description;
+        @JsonProperty("url")
+        private String url;
+        @JsonProperty("visibility")
+        private String visibility;
+        @JsonProperty("timeline_order")
+        private String timelineOrder;
+        @JsonProperty("collection_type")
+        private String collectionType;
+        @JsonProperty("custom_timeline_type")
+        private String collectionTimelineType;
+      }
+    }
+  }
+}

--- a/src/main/java/com/github/redouane59/twitter/dto/collections/TimeLineOrder.java
+++ b/src/main/java/com/github/redouane59/twitter/dto/collections/TimeLineOrder.java
@@ -1,0 +1,25 @@
+package com.github.redouane59.twitter.dto.collections;
+
+/**
+ * timeline_order used when creating a collection - https://api.twitter.com/1.1/collections/create.json
+ */
+public enum TimeLineOrder {
+
+    // oldest tweet first
+    CHRONOLOGICAL("tweet_chron"),
+    // order tweets are added to the collection (default)
+    CURATION_ORDER("curation_reverse_chron"),
+    // most recent tweet first
+    CHRONOLOGICAL_REVERSE("tweet_reverse_chron ");
+
+    private final String value;
+
+    TimeLineOrder(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+}

--- a/src/main/java/com/github/redouane59/twitter/helpers/RequestHelper.java
+++ b/src/main/java/com/github/redouane59/twitter/helpers/RequestHelper.java
@@ -4,6 +4,7 @@ import com.github.redouane59.twitter.TwitterClient;
 import com.github.redouane59.twitter.signature.Oauth1SigningInterceptor;
 import java.io.File;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,17 +22,17 @@ import se.akerfeldt.okhttp.signpost.SigningInterceptor;
 @Slf4j
 public class RequestHelper extends AbstractRequestHelper {
 
-  public <T> Optional<T> postRequest(String url, Map<String, String> parameters, Class<T> classType) {
+  public <T> Optional<T> postRequestWithBodyJson(String url, Map<String, String> parameters, String requestBodyJson, Class<T> classType) {
     T result = null;
     try {
-      HttpUrl.Builder httpBuilder = HttpUrl.parse(url).newBuilder();
+      HttpUrl.Builder httpBuilder = Objects.requireNonNull(HttpUrl.parse(url)).newBuilder();
       if (parameters != null) {
         for (Map.Entry<String, String> param : parameters.entrySet()) {
           httpBuilder.addQueryParameter(param.getKey(), param.getValue());
         }
       }
-      String      json        = TwitterClient.OBJECT_MAPPER.writeValueAsString(parameters);
-      RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"), json);
+      String      json        = requestBodyJson != null ? requestBodyJson : TwitterClient.OBJECT_MAPPER.writeValueAsString(parameters);
+      RequestBody requestBody = RequestBody.create(json, MediaType.parse("application/json"));
       Request request = new Request.Builder()
           .url(httpBuilder.build())
           .post(requestBody)
@@ -52,6 +53,11 @@ public class RequestHelper extends AbstractRequestHelper {
       LOGGER.error(e.getMessage(), e);
     }
     return Optional.ofNullable(result);
+
+  }
+
+  public <T> Optional<T> postRequest(String url, Map<String, String> parameters, Class<T> classType) {
+    return postRequestWithBodyJson(url, parameters, null, classType);
   }
 
   public <T> Optional<T> uploadMedia(String url, File file, Class<T> classType) {
@@ -111,12 +117,25 @@ public class RequestHelper extends AbstractRequestHelper {
   }
 
   public <T> Optional<T> getRequest(String url, Class<T> classType) {
+    return getRequestWithParameters(url, null, classType);
+  }
+
+
+  public <T> Optional<T> getRequestWithParameters(String url, Map<String, String> parameters, Class<T> classType) {
     T result = null;
     try {
+      HttpUrl.Builder httpBuilder = Objects.requireNonNull(HttpUrl.parse(url)).newBuilder();
+      if (parameters != null) {
+        for (Map.Entry<String, String> param : parameters.entrySet()) {
+          httpBuilder.addQueryParameter(param.getKey(), param.getValue());
+        }
+      }
+
       Request request = new Request.Builder()
-          .url(url)
+          .url(httpBuilder.build())
           .get()
           .build();
+
       Request signedRequest = this.getSignedRequest(request);
       Response response = this.getHttpClient(url)
                               .newCall(signedRequest).execute();

--- a/src/main/java/com/github/redouane59/twitter/helpers/URLHelper.java
+++ b/src/main/java/com/github/redouane59/twitter/helpers/URLHelper.java
@@ -49,9 +49,10 @@ public class URLHelper {
   private static final String TWEET_FORMAT_DETAILED         = "tweet.format=detailed";
   private static final String EXPANSIONS_RECENT_TWEET       = "expansions=most_recent_tweet_id";
   private static final String MAX_ID                        = "max_id";
+  private static final String COLLECTIONS                   = "/collections";
   private static final int    MAX_COUNT                     = 200;
   private static final int    RETWEET_MAX_COUNT             = 100;
-  private static final int    MAX_LOOKUP                    = 100;
+  public  static final int    MAX_LOOKUP                    = 100;
   public static final  String
                               ALL_USER_FIELDS               =
       "user.fields=id,created_at,username,name,location,url,verified,profile_image_url,public_metrics,pinned_tweet_id,description,protected";
@@ -322,5 +323,37 @@ public class URLHelper {
 
   public String getUploadMediaUrl(MediaCategory mediaCategory) {
     return "https://upload.twitter.com/1.1/media/upload.json?media_category=" + mediaCategory.label;
+  }
+
+  public String getCollectionsCreateUrl() {
+    return ROOT_URL_V1
+           + COLLECTIONS
+           + "/create.json";
+  }
+
+  public String getCollectionsCurateUrl() {
+    return ROOT_URL_V1
+           + COLLECTIONS
+           + "/entries/curate.json";
+  }
+
+  public String getCollectionsDestroyUrl(String collectionId) {
+    return ROOT_URL_V1 +
+           COLLECTIONS +
+           "/destroy.json" +
+           "?" +
+           ID +
+           "=" +
+           collectionId;
+  }
+
+  public String getCollectionsEntriesUrl(String collectionId) {
+    return ROOT_URL_V1 +
+           COLLECTIONS +
+           "/entries.json" +
+           "?" +
+           ID +
+           "=" +
+           collectionId;
   }
 }

--- a/src/test/java/com/github/redouane59/twitter/unit/CollectionsDeserializerTest.java
+++ b/src/test/java/com/github/redouane59/twitter/unit/CollectionsDeserializerTest.java
@@ -1,0 +1,165 @@
+package com.github.redouane59.twitter.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.redouane59.twitter.TwitterClient;
+import com.github.redouane59.twitter.dto.collections.CollectionsResponse;
+import com.github.redouane59.twitter.dto.collections.CollectionsResponse.Objects.Timelines.Timeline;
+import com.github.redouane59.twitter.dto.collections.CollectionsResponse.Response.Error;
+import com.github.redouane59.twitter.dto.collections.CollectionsResponse.Response.TimelineTweet;
+import com.github.redouane59.twitter.dto.tweet.TweetV1;
+import com.github.redouane59.twitter.dto.user.UserV1;
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the various collections endpoints:
+ * <ul>
+ *   <li><a href="https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-entries-curate">Collections Curate</a>  tests/collections_curate_example.json</li>
+ *   <li><a href="https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/get-collections-entries">Collections Entries</a>  tests/collections_entries_example.json</a></li>
+ *   <li><a https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-create">Collections Create</a>  tests/collections_create_example.json</a></li>
+ *   <li><a href="https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-destroy">Collections Destroy</a>  tests/collections_destroy_example.json</a></li>
+ * </ul>
+ *
+ * <br>
+ * The <a href="https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/overview/response_structures">Response Structures</a>are a bit different to traditional trwitter api
+ */
+public class CollectionsDeserializerTest {
+
+  // Example response from a call to curate a collection
+  private final File
+      collectionsCurateFile     =
+      new File(Objects.requireNonNull(getClass().getClassLoader().getResource("tests/collections_curate_example.json")).getFile());
+  private final CollectionsResponse
+      collectionsCurateResponse =
+      TwitterClient.OBJECT_MAPPER.readValue(collectionsCurateFile, CollectionsResponse.class);
+
+  // Example response from a call to get entries in a collection
+  private final File
+      collectionsEntriesFile     =
+      new File(Objects.requireNonNull(getClass().getClassLoader().getResource("tests/collections_entries_example.json")).getFile());
+  private final CollectionsResponse
+      collectionsEntriesResponse =
+      TwitterClient.OBJECT_MAPPER.readValue(collectionsEntriesFile, CollectionsResponse.class);
+
+  // Example response from a call to create a collection
+  private final File
+      collectionsCreateFile     =
+      new File(Objects.requireNonNull(getClass().getClassLoader().getResource("tests/collections_create_example.json")).getFile());
+  private final CollectionsResponse
+      collectionsCreateResponse =
+      TwitterClient.OBJECT_MAPPER.readValue(collectionsCreateFile, CollectionsResponse.class);
+
+  // Example response from a call to destroy a collection
+  private final File
+      collectionsDestroyFile     =
+      new File(Objects.requireNonNull(getClass().getClassLoader().getResource("tests/collections_destroy_example.json")).getFile());
+  private final CollectionsResponse
+      collectionsDestroyResponse =
+      TwitterClient.OBJECT_MAPPER.readValue(collectionsDestroyFile, CollectionsResponse.class);
+
+
+  public CollectionsDeserializerTest() throws IOException {
+  }
+
+  @Test
+  public void testCollectionsCurateHasErrors() {
+    assertTrue(collectionsCurateResponse.hasErrors());
+  }
+
+  @Test
+  public void testCollectionsDestroy() {
+    assertTrue(collectionsDestroyResponse.isDestroyed());
+  }
+
+  @Test
+  public void testCollectionsCurateErrors() {
+    assertEquals(4, collectionsCurateResponse.getResponse().getErrors().size());
+    Error error = collectionsCurateResponse.getResponse().getErrors().get(0);
+    assertEquals("duplicate", error.getReason());
+    assertEquals("add", error.getChange().getOperation());
+    assertEquals("390897780949925889", error.getChange().getTweetId());
+
+  }
+
+  @Test
+  public void testCollectionsCreateTimelineId() {
+    assertEquals("custom-1349447047020212224", collectionsCreateResponse.getResponse().getTimeLineId());
+  }
+
+  @Test
+  public void testCollectionsCreateTimeline() {
+    assertEquals("custom-1349447047020212224", collectionsCreateResponse.getResponse().getTimeLineId());
+    assertNotNull(collectionsCreateResponse.getObjects().getTimelines().getTimelineDetailsDetails().get("custom-1349447047020212224"));
+    assertEquals(1, collectionsCreateResponse.getObjects().getTimelines().get().size());
+
+    Timeline timeline = collectionsCreateResponse.getObjects().getTimelines().get().get(0);
+
+    assertEquals("https://twitter.com/LlSTENlNG_PARTY/timelines/1349447047020212224", timeline.getCollectionUrl());
+    assertEquals("1255057822959747073", timeline.getUserId());
+  }
+
+  @Test
+  public void testCollectionsCreateUsers() {
+    assertEquals(1, collectionsCreateResponse.getObjects().getUsers().get().size());
+    UserV1 userV1 = collectionsCreateResponse.getObjects().getUsers().get().get(0);
+    assertEquals(userV1, collectionsCreateResponse.getObjects().getUsers().getUserDetails().get(userV1.getId()));
+    assertEquals("Tim's Listening Party", userV1.getDisplayedName());
+    assertEquals("Updates and info about #TimsTwitterListeningParty", userV1.getDescription());
+    assertEquals(47244, userV1.getFollowersCount());
+    assertEquals(16248, userV1.getTweetCount());
+
+  }
+
+  @Test
+  public void testCollectionsEntriesTimeline() {
+    assertEquals("custom-1348368035900493824", collectionsEntriesResponse.getResponse().getTimeLineId());
+    assertEquals(3, collectionsEntriesResponse.getResponse().getTimeline().size());
+    TimelineTweet timelineTweet = collectionsEntriesResponse.getResponse().getTimeline().get(0);
+    assertEquals("HBgGY3VzdG9tFoDAuOW15a62JQAA", timelineTweet.getFeatureContext());
+    assertEquals("1348264201937149953", timelineTweet.getTweet().getId());
+    assertEquals("7875107834917625854", timelineTweet.getTweet().getSortIndex());
+  }
+
+
+  @Test
+  public void testCollectionsEntriesObjectTweets() {
+    assertNotNull(collectionsEntriesResponse.getObjects());
+    assertEquals(3, collectionsEntriesResponse.getObjects().getTweets().getTweetDetails().size());
+    assertEquals(3, collectionsEntriesResponse.getObjects().getTweets().get().size());
+    TweetV1 firstTweet = collectionsEntriesResponse.getObjects().getTweets().get().get(0);
+    // mapped by tweet id
+    assertEquals(collectionsEntriesResponse.getObjects().getTweets().getTweetDetails().get(firstTweet.getId()), firstTweet);
+
+    assertEquals("Kung fu city", firstTweet.getText());
+  }
+
+  @Test
+  public void testCollectionsEntriesPosition() {
+    assertNotNull(collectionsEntriesResponse.getResponse());
+    assertFalse(collectionsEntriesResponse.getResponse().getPosition().getWasTruncated());
+    assertEquals("7875026924025212925",collectionsEntriesResponse.getResponse().getPosition().getMinPosition());
+    assertEquals("7875107834917625854",collectionsEntriesResponse.getResponse().getPosition().getMaxPosition());
+  }
+
+  @Test
+  public void testCollectionsEntriesObjectUsers() {
+    assertNotNull(collectionsEntriesResponse.getObjects());
+    assertEquals(3, collectionsEntriesResponse.getObjects().getUsers().getUserDetails().size());
+    assertEquals(3, collectionsEntriesResponse.getObjects().getUsers().get().size());
+
+    UserV1 firstUser = collectionsEntriesResponse.getObjects().getUsers().get().get(0);
+    // mapped by tweet id
+    assertEquals(collectionsEntriesResponse.getObjects().getUsers().getUserDetails().get(firstUser.getId()), firstUser);
+
+    assertEquals("LlSTENlNG_PARTY", firstUser.getName());
+    assertEquals("Tim's Listening Party", firstUser.getDisplayedName());
+
+  }
+
+}

--- a/src/test/java/com/github/redouane59/twitter/unit/RequestHelperTest.java
+++ b/src/test/java/com/github/redouane59/twitter/unit/RequestHelperTest.java
@@ -62,4 +62,18 @@ public class RequestHelperTest {
     assertTrue(result.isPresent());
     assertEquals(401, result.get().get("status"));
   }
+
+  @Test
+  public void testRequestWithBodyJsonV1() {
+    Optional<LinkedHashMap>
+        result =
+        twitterClient.getRequestHelper().postRequestWithBodyJson(twitterClient.getUrlHelper().getLikeUrl("12345"),
+                                                                 new HashMap<>(),
+                                                                 "{\"changes\": [{\"op\":\"add\",\"tweet_id\":\"390897780949925889\"}],\"id\": \"custom-1348265030006042629\"}",
+                                                                 LinkedHashMap.class);
+    assertTrue(result.isPresent());
+    ArrayList<LinkedHashMap> errors = (ArrayList) result.get().get("errors");
+    assertNotNull(errors);
+    assertEquals(89, errors.get(0).get("code"));
+  }
 }

--- a/src/test/resources/tests/collections_create_example.json
+++ b/src/test/resources/tests/collections_create_example.json
@@ -1,0 +1,84 @@
+{
+  "objects": {
+    "users": {
+      "1255057822959747073": {
+        "id": 1255057822959747073,
+        "id_str": "1255057822959747073",
+        "name": "Tim's Listening Party",
+        "screen_name": "LlSTENlNG_PARTY",
+        "location": "",
+        "description": "Updates and info about #TimsTwitterListeningParty",
+        "url": "https:\/\/t.co\/798q3za44i",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "https:\/\/t.co\/798q3za44i",
+                "expanded_url": "https:\/\/timstwitterlisteningparty.com\/",
+                "display_url": "timstwitterlisteningparty.com",
+                "indices": [
+                  0,
+                  23
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 47244,
+        "friends_count": 1,
+        "listed_count": 205,
+        "created_at": "Tue Apr 28 08:55:51 +0000 2020",
+        "favourites_count": 17471,
+        "utc_offset": null,
+        "time_zone": null,
+        "geo_enabled": false,
+        "verified": true,
+        "statuses_count": 16248,
+        "lang": null,
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "F5F8FA",
+        "profile_background_image_url": null,
+        "profile_background_image_url_https": null,
+        "profile_background_tile": false,
+        "profile_image_url": "http:\/\/pbs.twimg.com\/profile_images\/1305818491614892032\/X3db_cyC_normal.jpg",
+        "profile_image_url_https": "https:\/\/pbs.twimg.com\/profile_images\/1305818491614892032\/X3db_cyC_normal.jpg",
+        "profile_banner_url": "https:\/\/pbs.twimg.com\/profile_banners\/1255057822959747073\/1588146894",
+        "profile_link_color": "1DA1F2",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "has_extended_profile": false,
+        "default_profile": true,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false,
+        "translator_type": "none"
+      }
+    },
+    "timelines": {
+      "custom-1349447047020212224": {
+        "name": "test",
+        "user_id": "1255057822959747073",
+        "collection_url": "https:\/\/twitter.com\/LlSTENlNG_PARTY\/timelines\/1349447047020212224",
+        "custom_timeline_url": "https:\/\/twitter.com\/LlSTENlNG_PARTY\/timelines\/1349447047020212224",
+        "description": "test-deleteme",
+        "url": "www.timstwitterlisteningparty.com",
+        "visibility": "public",
+        "timeline_order": "tweet_chron",
+        "collection_type": "user",
+        "custom_timeline_type": "user"
+      }
+    }
+  },
+  "response": {
+    "timeline_id": "custom-1349447047020212224"
+  }
+}

--- a/src/test/resources/tests/collections_curate_example.json
+++ b/src/test/resources/tests/collections_curate_example.json
@@ -1,0 +1,36 @@
+{
+  "objects": {},
+  "response": {
+    "timeline_id": "custom-1348368035900493824",
+    "errors": [
+      {
+        "reason": "duplicate",
+        "change": {
+          "op": "add",
+          "tweet_id": "390897780949925889"
+        }
+      },
+      {
+        "reason": "duplicate",
+        "change": {
+          "op": "add",
+          "tweet_id": "390853164611555329"
+        }
+      },
+      {
+        "reason": "duplicate",
+        "change": {
+          "op": "add",
+          "tweet_id": "390892747810295808"
+        }
+      },
+      {
+        "reason": "duplicate",
+        "change": {
+          "op": "add",
+          "tweet_id": "390898463090561024"
+        }
+      }
+    ]
+  }
+}

--- a/src/test/resources/tests/collections_destroy_example.json
+++ b/src/test/resources/tests/collections_destroy_example.json
@@ -1,0 +1,3 @@
+{
+  "destroyed": true
+}

--- a/src/test/resources/tests/collections_entries_example.json
+++ b/src/test/resources/tests/collections_entries_example.json
@@ -1,0 +1,343 @@
+{
+  "objects": {
+    "tweets": {
+      "1348264201937149953": {
+        "created_at": "Sun Jan 10 13:43:29 +0000 2021",
+        "id": 1348264201937149953,
+        "id_str": "1348264201937149953",
+        "text": "Kung fu city",
+        "truncated": false,
+        "entities": {
+          "hashtags": [],
+          "symbols": [],
+          "user_mentions": [],
+          "urls": []
+        },
+        "source": "\u003ca href=\"http:\/\/twitter.com\/download\/iphone\" rel=\"nofollow\"\u003eTwitter for iPhone\u003c\/a\u003e",
+        "in_reply_to_status_id": null,
+        "in_reply_to_status_id_str": null,
+        "in_reply_to_user_id": null,
+        "in_reply_to_user_id_str": null,
+        "in_reply_to_screen_name": null,
+        "user": {
+          "id": 21181713,
+          "id_str": "21181713"
+        },
+        "geo": null,
+        "coordinates": null,
+        "place": null,
+        "contributors": null,
+        "is_quote_status": false,
+        "retweet_count": 173,
+        "favorite_count": 2398,
+        "favorited": false,
+        "retweeted": false,
+        "lang": "tl"
+      },
+      "1348343713840459777": {
+        "created_at": "Sun Jan 10 18:59:27 +0000 2021",
+        "id": 1348343713840459777,
+        "id_str": "1348343713840459777",
+        "text": "Harvey White stood out as well. Lovely left peg.",
+        "truncated": false,
+        "entities": {
+          "hashtags": [],
+          "symbols": [],
+          "user_mentions": [],
+          "urls": []
+        },
+        "source": "\u003ca href=\"http:\/\/twitter.com\/download\/android\" rel=\"nofollow\"\u003eTwitter for Android\u003c\/a\u003e",
+        "in_reply_to_status_id": null,
+        "in_reply_to_status_id_str": null,
+        "in_reply_to_user_id": null,
+        "in_reply_to_user_id_str": null,
+        "in_reply_to_screen_name": null,
+        "user": {
+          "id": 372796650,
+          "id_str": "372796650"
+        },
+        "geo": null,
+        "coordinates": null,
+        "place": null,
+        "contributors": null,
+        "is_quote_status": false,
+        "retweet_count": 0,
+        "favorite_count": 90,
+        "favorited": false,
+        "retweeted": false,
+        "lang": "en"
+      },
+      "1348345112829562882": {
+        "created_at": "Sun Jan 10 19:05:00 +0000 2021",
+        "id": 1348345112829562882,
+        "id_str": "1348345112829562882",
+        "text": "@LoveTheShirt Apart from today's free-kicks!",
+        "truncated": false,
+        "entities": {
+          "hashtags": [],
+          "symbols": [],
+          "user_mentions": [
+            {
+              "screen_name": "LoveTheShirt",
+              "name": "The Fighting Cock",
+              "id": 372796650,
+              "id_str": "372796650",
+              "indices": [
+                0,
+                13
+              ]
+            }
+          ],
+          "urls": []
+        },
+        "source": "\u003ca href=\"http:\/\/twitter.com\/download\/android\" rel=\"nofollow\"\u003eTwitter for Android\u003c\/a\u003e",
+        "in_reply_to_status_id": 1348343713840459777,
+        "in_reply_to_status_id_str": "1348343713840459777",
+        "in_reply_to_user_id": 372796650,
+        "in_reply_to_user_id_str": "372796650",
+        "in_reply_to_screen_name": "LoveTheShirt",
+        "user": {
+          "id": 412971864,
+          "id_str": "412971864"
+        },
+        "geo": null,
+        "coordinates": null,
+        "place": null,
+        "contributors": null,
+        "is_quote_status": false,
+        "retweet_count": 0,
+        "favorite_count": 0,
+        "favorited": false,
+        "retweeted": false,
+        "lang": "en"
+      }
+    },
+    "users": {
+      "1255057822959747073": {
+        "id": 1255057822959747073,
+        "id_str": "1255057822959747073",
+        "name": "Tim's Listening Party",
+        "screen_name": "LlSTENlNG_PARTY",
+        "location": "",
+        "description": "Updates and info about #TimsTwitterListeningParty",
+        "url": "https:\/\/t.co\/798q3za44i",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "https:\/\/t.co\/798q3za44i",
+                "expanded_url": "https:\/\/timstwitterlisteningparty.com\/",
+                "display_url": "timstwitterlisteningparty.com",
+                "indices": [
+                  0,
+                  23
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 46999,
+        "friends_count": 1,
+        "listed_count": 203,
+        "created_at": "Tue Apr 28 08:55:51 +0000 2020",
+        "favourites_count": 17262,
+        "utc_offset": null,
+        "time_zone": null,
+        "geo_enabled": false,
+        "verified": true,
+        "statuses_count": 16063,
+        "lang": null,
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "F5F8FA",
+        "profile_background_image_url": null,
+        "profile_background_image_url_https": null,
+        "profile_background_tile": false,
+        "profile_image_url": "http:\/\/pbs.twimg.com\/profile_images\/1305818491614892032\/X3db_cyC_normal.jpg",
+        "profile_image_url_https": "https:\/\/pbs.twimg.com\/profile_images\/1305818491614892032\/X3db_cyC_normal.jpg",
+        "profile_banner_url": "https:\/\/pbs.twimg.com\/profile_banners\/1255057822959747073\/1588146894",
+        "profile_link_color": "1DA1F2",
+        "profile_sidebar_border_color": "C0DEED",
+        "profile_sidebar_fill_color": "DDEEF6",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "has_extended_profile": false,
+        "default_profile": true,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false,
+        "translator_type": "none"
+      },
+      "21181713": {
+        "id": 21181713,
+        "id_str": "21181713",
+        "name": "Liam Gallagher",
+        "screen_name": "liamgallagher",
+        "location": "",
+        "description": "RNR STAR GODLIKE RASTA ICON LEGEND BIBLICAL OMNIPRESENT PROPHET SPIRITUAL MAJESTICAL CELESTIAL OPTIMYSTIC BUDDHIST JEDI APPROACHABLE ZEN LOVER HUMBLE \ud83d\udc1d",
+        "url": null,
+        "entities": {
+          "description": {
+            "urls": []
+          }
+        },
+        "protected": false,
+        "followers_count": 3457527,
+        "friends_count": 0,
+        "listed_count": 6196,
+        "created_at": "Wed Feb 18 09:23:31 +0000 2009",
+        "favourites_count": 11,
+        "utc_offset": null,
+        "time_zone": null,
+        "geo_enabled": true,
+        "verified": true,
+        "statuses_count": 11020,
+        "lang": null,
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "000000",
+        "profile_background_image_url": "http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png",
+        "profile_background_image_url_https": "https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png",
+        "profile_background_tile": true,
+        "profile_image_url": "http:\/\/pbs.twimg.com\/profile_images\/970644649013665793\/aKUB79Yd_normal.jpg",
+        "profile_image_url_https": "https:\/\/pbs.twimg.com\/profile_images\/970644649013665793\/aKUB79Yd_normal.jpg",
+        "profile_banner_url": "https:\/\/pbs.twimg.com\/profile_banners\/21181713\/1520254118",
+        "profile_link_color": "4A4A4A",
+        "profile_sidebar_border_color": "EBEBEB",
+        "profile_sidebar_fill_color": "F7F7F7",
+        "profile_text_color": "333333",
+        "profile_use_background_image": true,
+        "has_extended_profile": false,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false,
+        "translator_type": "none"
+      },
+      "372796650": {
+        "id": 372796650,
+        "id_str": "372796650",
+        "name": "The Fighting Cock",
+        "screen_name": "LoveTheShirt",
+        "location": "Tottenham",
+        "description": "Tottenham Podcast \/ Fanzine \/ Website \/ Merch \n\nJoin our Patreon for extra content: https:\/\/t.co\/LtrgmjfUNL",
+        "url": "https:\/\/t.co\/mIDIYpKUfs",
+        "entities": {
+          "url": {
+            "urls": [
+              {
+                "url": "https:\/\/t.co\/mIDIYpKUfs",
+                "expanded_url": "http:\/\/www.thefightingcock.co.uk",
+                "display_url": "thefightingcock.co.uk",
+                "indices": [
+                  0,
+                  23
+                ]
+              }
+            ]
+          },
+          "description": {
+            "urls": [
+              {
+                "url": "https:\/\/t.co\/LtrgmjfUNL",
+                "expanded_url": "http:\/\/www.patreon.com\/thefightingcock",
+                "display_url": "patreon.com\/thefightingcock",
+                "indices": [
+                  84,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        "protected": false,
+        "followers_count": 55979,
+        "friends_count": 12,
+        "listed_count": 584,
+        "created_at": "Tue Sep 13 12:49:08 +0000 2011",
+        "favourites_count": 3057,
+        "utc_offset": null,
+        "time_zone": null,
+        "geo_enabled": true,
+        "verified": false,
+        "statuses_count": 19870,
+        "lang": null,
+        "contributors_enabled": false,
+        "is_translator": false,
+        "is_translation_enabled": false,
+        "profile_background_color": "1B3A57",
+        "profile_background_image_url": "http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png",
+        "profile_background_image_url_https": "https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png",
+        "profile_background_tile": false,
+        "profile_image_url": "http:\/\/pbs.twimg.com\/profile_images\/708068212395655168\/1zAPVBUl_normal.jpg",
+        "profile_image_url_https": "https:\/\/pbs.twimg.com\/profile_images\/708068212395655168\/1zAPVBUl_normal.jpg",
+        "profile_banner_url": "https:\/\/pbs.twimg.com\/profile_banners\/372796650\/1398276776",
+        "profile_link_color": "43B5E6",
+        "profile_sidebar_border_color": "FFFFFF",
+        "profile_sidebar_fill_color": "BACAD9",
+        "profile_text_color": "4F4F4F",
+        "profile_use_background_image": true,
+        "has_extended_profile": false,
+        "default_profile": false,
+        "default_profile_image": false,
+        "following": false,
+        "follow_request_sent": false,
+        "notifications": false,
+        "translator_type": "none"
+      }
+    },
+    "timelines": {
+      "custom-1348368035900493824": {
+        "name": "test",
+        "user_id": "1255057822959747073",
+        "collection_url": "https:\/\/twitter.com\/LlSTENlNG_PARTY\/timelines\/1348368035900493824",
+        "custom_timeline_url": "https:\/\/twitter.com\/LlSTENlNG_PARTY\/timelines\/1348368035900493824",
+        "description": "test-deleteme",
+        "url": "www.timstwitterlisteningparty.com",
+        "visibility": "public",
+        "timeline_order": "tweet_chron",
+        "collection_type": "user",
+        "custom_timeline_type": "user"
+      }
+    }
+  },
+  "response": {
+    "timeline": [
+      {
+        "tweet": {
+          "id": "1348264201937149953",
+          "sort_index": "7875107834917625854"
+        },
+        "feature_context": "HBgGY3VzdG9tFoDAuOW15a62JQAA"
+      },
+      {
+        "tweet": {
+          "id": "1348343713840459777",
+          "sort_index": "7875028323014316030"
+        },
+        "feature_context": "HBgGY3VzdG9tFoDAuOW15a62JQAA"
+      },
+      {
+        "tweet": {
+          "id": "1348345112829562882",
+          "sort_index": "7875026924025212925"
+        },
+        "feature_context": "HBgGY3VzdG9tFoDAuOW15a62JQAA"
+      }
+    ],
+    "timeline_id": "custom-1348368035900493824",
+    "position": {
+      "max_position": "7875107834917625854",
+      "min_position": "7875026924025212925",
+      "was_truncated": false
+    }
+  }
+}


### PR DESCRIPTION
4 Collections Endpoints from the v1 [Twitter Collections API ](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/overview)

1. [Collections Create](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-create)
2. [Collections Curate](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-entries-curate)
3. [Collections Entries](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/get-collections-entries)
4. [Collections Destroy](https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-destroy)

Not sure how widely used the collections api is but I use it a lot for the timstwitterlisteningparty.com site so thought I would share! 

Can add the other methods if of any use.
