### PR TITLE
Using Socket ReadTimeOut break the Twitter Stream

### DIFF
--- a/src/main/java/com/github/redouane59/twitter/helpers/URLHelper.java
+++ b/src/main/java/com/github/redouane59/twitter/helpers/URLHelper.java
@@ -1,9 +1,8 @@
 package com.github.redouane59.twitter.helpers;
 
+import com.github.redouane59.twitter.dto.tweet.MediaCategory;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import com.github.redouane59.twitter.dto.tweet.MediaCategory;
 
 import lombok.Getter;
 import lombok.Setter;


### PR DESCRIPTION
Hi @redouane59 ,

I was having trouble to stop the stream using stopFilteredStream. It would take up to 30 sec to be disconnected (and once, never).
So i dig in the TwitterClient options to set a timeout on the socket, and thus, discovered that the loop to read data was broken in this setup.
The consumer has been adapted to allow readtimeout and continue to wait for tweets.
Now, stopFilteredStream() returns almost immediatly with a timeout of 2 sec.

Let me know if you feel like there is some room for improvement.
Best Regards,
Greg.