### PR TITLE
feat: implement recent tweet counts v2 endpoint

### DIFF
--- a/src/main/java/com/github/redouane59/twitter/ITwitterClientV2.java
+++ b/src/main/java/com/github/redouane59/twitter/ITwitterClientV2.java
@@ -308,19 +308,38 @@ public interface ITwitterClientV2 {
 
 
   /**
-   * The recent Tweet counts endpoint returns count of Tweets from the last seven days that match a search query.
+   * The recent Tweet counts endpoint returns count of Tweets from the last seven days that match a search query calling
+   * https://api.twitter.com/2/tweets/counts/recent
    *
    * @param query One rule for matching Tweets
    */
-  TweetsCountsList getTweetsCounts(String query);
+  TweetsCountsList getTweetCounts(String query);
 
   /**
-   * The recent Tweet counts endpoint returns count of Tweets from the last seven days that match a search query.
+   * The recent Tweet counts endpoint returns count of Tweets from the last seven days that match a search query calling
+   * https://api.twitter.com/2/tweets/counts/recent
    *
    * @param query One rule for matching Tweets
-   * @param additionnalParameters parameters accepted are start_time, end_time, since_id, until_id, and granularity
+   * @param additionnalParameters parameters accepted are startTime, endTime, sinceId, untilId, and granularity
    */
-  TweetsCountsList getTweetsCounts(String query, AdditionnalParameters additionnalParameters);
+  TweetsCountsList getTweetCounts(String query, AdditionnalParameters additionnalParameters);
 
+  /**
+   * The full-archive search endpoint returns the complete history of public Tweets matching a search query; since the first Tweet was created March
+   * 26, 2006 calling https://api.twitter.com/2/tweets/counts/all
+   *
+   * @param query One query for matching Tweets.
+   */
+  TweetsCountsList getTweetCountsFullArchive(String query);
+
+  /**
+   * The full-archive search endpoint returns the complete history of public Tweets matching a search query; since the first Tweet was created March
+   * 26, 2006 calling https://api.twitter.com/2/tweets/counts/all
+   *
+   * @param query One query for matching Tweets.
+   * @param additionnalParameters parameters accepted are startTime, endTime, sinceId, untilId, granularity and nextToken
+   */
+  TweetsCountsList getTweetCountsFullArchive(String query, AdditionnalParameters additionnalParameters);
+  
 }
 

--- a/src/main/java/com/github/redouane59/twitter/ITwitterClientV2.java
+++ b/src/main/java/com/github/redouane59/twitter/ITwitterClientV2.java
@@ -1,5 +1,6 @@
 package com.github.redouane59.twitter;
 
+import com.github.redouane59.twitter.dto.endpoints.AdditionnalParameters;
 import com.github.redouane59.twitter.dto.others.BlockResponse;
 import com.github.redouane59.twitter.dto.stream.StreamRules.StreamMeta;
 import com.github.redouane59.twitter.dto.stream.StreamRules.StreamRule;
@@ -7,6 +8,7 @@ import com.github.redouane59.twitter.dto.tweet.LikeResponse;
 import com.github.redouane59.twitter.dto.tweet.Tweet;
 import com.github.redouane59.twitter.dto.tweet.TweetListV2;
 import com.github.redouane59.twitter.dto.tweet.TweetSearchResponse;
+import com.github.redouane59.twitter.dto.tweet.TweetsCountsList;
 import com.github.redouane59.twitter.dto.user.FollowResponse;
 import com.github.redouane59.twitter.dto.user.User;
 import com.github.redouane59.twitter.dto.user.UserListV2;
@@ -303,5 +305,22 @@ public interface ITwitterClientV2 {
    * @param userId ID of the user to request liked Tweets for.
    */
   TweetListV2 getLikedTweets(String userId);
+
+
+  /**
+   * The recent Tweet counts endpoint returns count of Tweets from the last seven days that match a search query.
+   *
+   * @param query One rule for matching Tweets
+   */
+  TweetsCountsList getTweetsCounts(String query);
+
+  /**
+   * The recent Tweet counts endpoint returns count of Tweets from the last seven days that match a search query.
+   *
+   * @param query One rule for matching Tweets
+   * @param additionnalParameters parameters accepted are start_time, end_time, since_id, until_id, and granularity
+   */
+  TweetsCountsList getTweetsCounts(String query, AdditionnalParameters additionnalParameters);
+
 }
 

--- a/src/main/java/com/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/com/github/redouane59/twitter/TwitterClient.java
@@ -11,6 +11,7 @@ import com.github.redouane59.twitter.dto.collections.TimeLineOrder;
 import com.github.redouane59.twitter.dto.dm.DirectMessage;
 import com.github.redouane59.twitter.dto.dm.DmEvent;
 import com.github.redouane59.twitter.dto.dm.DmListAnswer;
+import com.github.redouane59.twitter.dto.endpoints.AdditionnalParameters;
 import com.github.redouane59.twitter.dto.getrelationship.IdList;
 import com.github.redouane59.twitter.dto.getrelationship.RelationshipObjectResponse;
 import com.github.redouane59.twitter.dto.others.BlockResponse;
@@ -32,6 +33,7 @@ import com.github.redouane59.twitter.dto.tweet.TweetV1;
 import com.github.redouane59.twitter.dto.tweet.TweetV1Deserializer;
 import com.github.redouane59.twitter.dto.tweet.TweetV2;
 import com.github.redouane59.twitter.dto.tweet.TweetV2.TweetData;
+import com.github.redouane59.twitter.dto.tweet.TweetsCountsList;
 import com.github.redouane59.twitter.dto.tweet.UploadMediaResponse;
 import com.github.redouane59.twitter.dto.user.FollowBody;
 import com.github.redouane59.twitter.dto.user.FollowResponse;
@@ -91,6 +93,11 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   private              TwitterCredentials twitterCredentials;
   private static final String             IDS                                  = "ids";
   private static final String             QUERY                                = "query";
+  private static final String             GRANULARITY                          = "granularity";
+  private static final String             SINCE_ID                             = "since_id";
+  private static final String             UNTIL_ID                             = "until_id";
+  private static final String             START_TIME                           = "start_time";
+  private static final String             END_TIME                             = "end_time";
   private static final String             MAX_RESULTS                          = "max_results";
   private static final String             USERS                                = "users";
   private static final String             CURSOR                               = "cursor";
@@ -323,6 +330,34 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   public TweetListV2 getLikedTweets(final String userId) {
     String url = this.getUrlHelper().getLikedTweetsUrl(userId);
     return getRequestHelper().getRequest(url, TweetListV2.class).orElseThrow(NoSuchElementException::new);
+  }
+
+  @Override
+  public TweetsCountsList getTweetsCounts(final String query) {
+    return this.getTweetsCounts(query, null);
+  }
+
+  @Override
+  public TweetsCountsList getTweetsCounts(final String query, AdditionnalParameters additionnalParameters) {
+    String              url        = this.getUrlHelper().getTweetsCountsUrl();
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(QUERY, query);
+    if (additionnalParameters.getGranularity() != null) {
+      parameters.put(GRANULARITY, additionnalParameters.getGranularity());
+    }
+    if (additionnalParameters.getStartTime() != null) {
+      parameters.put(START_TIME, ConverterHelper.getStringFromDateV2(additionnalParameters.getStartTime()));
+    }
+    if (additionnalParameters.getEndTime() != null) {
+      parameters.put(END_TIME, ConverterHelper.getStringFromDateV2(additionnalParameters.getEndTime()));
+    }
+    if (additionnalParameters.getSinceId() != null) {
+      parameters.put(SINCE_ID, additionnalParameters.getSinceId());
+    }
+    if (additionnalParameters.getUntilId() != null) {
+      parameters.put(UNTIL_ID, additionnalParameters.getUntilId());
+    }
+    return getRequestHelperV2().getRequestWithParameters(url, parameters, TweetsCountsList.class).orElseThrow(NoSuchElementException::new);
   }
 
   @Override

--- a/src/main/java/com/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/com/github/redouane59/twitter/TwitterClient.java
@@ -333,13 +333,28 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   }
 
   @Override
-  public TweetsCountsList getTweetsCounts(final String query) {
-    return this.getTweetsCounts(query, null);
+  public TweetsCountsList getTweetCounts(final String query) {
+    return this.getTweetCounts(query, null);
   }
 
   @Override
-  public TweetsCountsList getTweetsCounts(final String query, AdditionnalParameters additionnalParameters) {
-    String              url        = this.getUrlHelper().getTweetsCountsUrl();
+  public TweetsCountsList getTweetCounts(final String query, AdditionnalParameters additionnalParameters) {
+    String url = this.getUrlHelper().getTweetsCountsUrl();
+    return this.getTweetCounts(url, query, additionnalParameters);
+  }
+
+  @Override
+  public TweetsCountsList getTweetCountsFullArchive(final String query) {
+    return this.getTweetCountsFullArchive(query, null);
+  }
+
+  @Override
+  public TweetsCountsList getTweetCountsFullArchive(final String query, AdditionnalParameters additionnalParameters) {
+    String url = this.getUrlHelper().getTweetsCountsUrl();
+    return this.getTweetCounts(url, query, additionnalParameters);
+  }
+
+  private TweetsCountsList getTweetCounts(String url, final String query, AdditionnalParameters additionnalParameters) {
     Map<String, String> parameters = new HashMap<>();
     parameters.put(QUERY, query);
     if (additionnalParameters.getGranularity() != null) {
@@ -356,6 +371,9 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     }
     if (additionnalParameters.getUntilId() != null) {
       parameters.put(UNTIL_ID, additionnalParameters.getUntilId());
+    }
+    if (additionnalParameters.getNextToken() != null) {
+      parameters.put(NEXT_TOKEN, additionnalParameters.getNextToken());
     }
     return getRequestHelperV2().getRequestWithParameters(url, parameters, TweetsCountsList.class).orElseThrow(NoSuchElementException::new);
   }

--- a/src/main/java/com/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/com/github/redouane59/twitter/TwitterClient.java
@@ -334,7 +334,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
 
   @Override
   public TweetsCountsList getTweetCounts(final String query) {
-    return this.getTweetCounts(query, null);
+    return this.getTweetCounts(query, AdditionnalParameters.builder().build());
   }
 
   @Override
@@ -345,12 +345,12 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
 
   @Override
   public TweetsCountsList getTweetCountsFullArchive(final String query) {
-    return this.getTweetCountsFullArchive(query, null);
+    return this.getTweetCountsFullArchive(query, AdditionnalParameters.builder().build());
   }
 
   @Override
   public TweetsCountsList getTweetCountsFullArchive(final String query, AdditionnalParameters additionnalParameters) {
-    String url = this.getUrlHelper().getTweetsCountsUrl();
+    String url = this.getUrlHelper().getTweetsCountsFullArchiveUrl();
     return this.getTweetCounts(url, query, additionnalParameters);
   }
 

--- a/src/main/java/com/github/redouane59/twitter/dto/endpoints/AdditionnalParameters.java
+++ b/src/main/java/com/github/redouane59/twitter/dto/endpoints/AdditionnalParameters.java
@@ -1,0 +1,21 @@
+package com.github.redouane59.twitter.dto.endpoints;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AdditionnalParameters {
+
+  @JsonProperty("start_time")
+  private LocalDateTime startTime;
+  @JsonProperty("end_time")
+  private LocalDateTime endTime;
+  @JsonProperty("since_id")
+  private String        sinceId;
+  @JsonProperty("until_id")
+  private String        untilId;
+  private String        granularity;
+}

--- a/src/main/java/com/github/redouane59/twitter/dto/endpoints/AdditionnalParameters.java
+++ b/src/main/java/com/github/redouane59/twitter/dto/endpoints/AdditionnalParameters.java
@@ -20,4 +20,6 @@ public class AdditionnalParameters {
   @JsonProperty("until_id")
   private String        untilId;
   private String        granularity;
+  @JsonProperty("next_token")
+  private String        nextToken;
 }

--- a/src/main/java/com/github/redouane59/twitter/dto/endpoints/AdditionnalParameters.java
+++ b/src/main/java/com/github/redouane59/twitter/dto/endpoints/AdditionnalParameters.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Builder
 @Getter
+@Setter
 public class AdditionnalParameters {
 
   @JsonProperty("start_time")

--- a/src/main/java/com/github/redouane59/twitter/dto/tweet/TweetsCountsList.java
+++ b/src/main/java/com/github/redouane59/twitter/dto/tweet/TweetsCountsList.java
@@ -1,0 +1,56 @@
+package com.github.redouane59.twitter.dto.tweet;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.github.redouane59.twitter.helpers.ConverterHelper;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class TweetsCountsList {
+
+  private List<TweetCountData> data;
+
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  @Getter
+  public static class TweetCountData {
+
+    @JsonProperty("tweet_count")
+    private int           tweetCount;
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    private LocalDateTime start;
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    private LocalDateTime end;
+  }
+
+  public static class LocalDateDeserializer extends StdDeserializer<LocalDateTime> {
+
+    private static final long serialVersionUID = 1L;
+
+    protected LocalDateDeserializer() {
+      super(LocalDateTime.class);
+    }
+
+
+    @Override
+    public LocalDateTime deserialize(JsonParser jp, DeserializationContext ctxt)
+    throws IOException {
+      return ConverterHelper.getDateFromTwitterDateV2(jp.readValueAs(String.class));
+    }
+
+  }
+
+}

--- a/src/main/java/com/github/redouane59/twitter/dto/tweet/TweetsCountsList.java
+++ b/src/main/java/com/github/redouane59/twitter/dto/tweet/TweetsCountsList.java
@@ -43,8 +43,7 @@ public class TweetsCountsList {
     protected LocalDateDeserializer() {
       super(LocalDateTime.class);
     }
-
-
+    
     @Override
     public LocalDateTime deserialize(JsonParser jp, DeserializationContext ctxt)
     throws IOException {

--- a/src/main/java/com/github/redouane59/twitter/dto/tweet/TweetsCountsList.java
+++ b/src/main/java/com/github/redouane59/twitter/dto/tweet/TweetsCountsList.java
@@ -21,6 +21,7 @@ import lombok.NoArgsConstructor;
 public class TweetsCountsList {
 
   private List<TweetCountData> data;
+  private TweetCountMeta       meta;
 
   @AllArgsConstructor
   @NoArgsConstructor
@@ -43,13 +44,25 @@ public class TweetsCountsList {
     protected LocalDateDeserializer() {
       super(LocalDateTime.class);
     }
-    
+
     @Override
     public LocalDateTime deserialize(JsonParser jp, DeserializationContext ctxt)
     throws IOException {
       return ConverterHelper.getDateFromTwitterDateV2(jp.readValueAs(String.class));
     }
 
+  }
+
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  @Getter
+  public static class TweetCountMeta {
+
+    @JsonProperty("total_tweet_count")
+    private int    totalTweetCount;
+    @JsonProperty("next_token")
+    private String nextToken;
   }
 
 }

--- a/src/main/java/com/github/redouane59/twitter/helpers/URLHelper.java
+++ b/src/main/java/com/github/redouane59/twitter/helpers/URLHelper.java
@@ -33,6 +33,8 @@ public class URLHelper {
   private static final String SEARCH                        = "/search";
   private static final String SAMPLE                        = "/sample";
   private static final String STREAM                        = "/stream";
+  private static final String COUNTS                        = "/counts";
+  private static final String RECENT                        = "/recent";
   private static final String THIRTY_DAYS                   = "/30day";
   private static final String FULL_ARCHIVE                  = "/fullarchive";
   private static final String ACCOUNT_ACTIVITY              = "/account_activity/all";
@@ -64,7 +66,7 @@ public class URLHelper {
   public static final  String LAST_TWEET_LIST_URL           = ROOT_URL_V1 + STATUSES + USER_TIMELINE;
   public static final  String RATE_LIMIT_URL                = ROOT_URL_V1 + "/application/rate_limit_status.json";
   public static final  String SEARCH_TWEET_STANDARD_URL     = ROOT_URL_V1 + SEARCH + TWEETS + JSON;
-  public static final  String SEARCH_TWEET_7_DAYS_URL       = ROOT_URL_V2 + TWEETS + SEARCH + "/recent";
+  public static final  String SEARCH_TWEET_7_DAYS_URL       = ROOT_URL_V2 + TWEETS + SEARCH + RECENT;
   public static final  String SEARCH_TWEET_FULL_ARCHIVE_URL = ROOT_URL_V2 + TWEETS + SEARCH + "/all" + "?" + EXPANSION + ALL_EXPANSIONS;
   public static final  String GET_BEARER_TOKEN_URL          = "https://api.twitter.com/oauth2/token";
   public static final  String GET_OAUTH1_TOKEN_URL          = "https://api.twitter.com/oauth/request_token";
@@ -431,6 +433,10 @@ public class URLHelper {
 
   public String getPostDmUrl() {
     return ROOT_URL_V1 + DIRECT_MESSAGE_EVENTS + "/new.json";
+  }
+
+  public String getTweetsCountsUrl() {
+    return ROOT_URL_V2 + TWEETS + COUNTS + RECENT;
   }
 
 }

--- a/src/main/java/com/github/redouane59/twitter/helpers/URLHelper.java
+++ b/src/main/java/com/github/redouane59/twitter/helpers/URLHelper.java
@@ -35,6 +35,7 @@ public class URLHelper {
   private static final String STREAM                        = "/stream";
   private static final String COUNTS                        = "/counts";
   private static final String RECENT                        = "/recent";
+  private static final String ALL                           = "/all";
   private static final String THIRTY_DAYS                   = "/30day";
   private static final String FULL_ARCHIVE                  = "/fullarchive";
   private static final String ACCOUNT_ACTIVITY              = "/account_activity/all";
@@ -437,6 +438,10 @@ public class URLHelper {
 
   public String getTweetsCountsUrl() {
     return ROOT_URL_V2 + TWEETS + COUNTS + RECENT;
+  }
+
+  public String getTweetsCountsFullArchiveUrl() {
+    return ROOT_URL_V2 + TWEETS + COUNTS + ALL;
   }
 
 }

--- a/src/test/java/com/github/redouane59/twitter/nrt/ITwitterClientV2Test.java
+++ b/src/test/java/com/github/redouane59/twitter/nrt/ITwitterClientV2Test.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.redouane59.twitter.TwitterClient;
+import com.github.redouane59.twitter.dto.endpoints.AdditionnalParameters;
 import com.github.redouane59.twitter.dto.stream.StreamRules.StreamMeta;
 import com.github.redouane59.twitter.dto.stream.StreamRules.StreamRule;
 import com.github.redouane59.twitter.dto.tweet.Tweet;
@@ -301,6 +302,18 @@ public class ITwitterClientV2Test {
   @Test
   public void testGetTweetCount() {
     TweetsCountsList result = twitterClient.getTweetsCounts("@Twitter");
+    assertTrue(result.getData().size() > 0);
+    assertTrue(result.getData().get(0).getTweetCount() > 0);
+  }
+
+  @Test
+  public void testGetTweetCountsWithParams() {
+    TweetsCountsList
+        result =
+        twitterClient.getTweetsCounts("@Twitter", AdditionnalParameters.builder()
+                                                                       .startTime(ConverterHelper.dayBeforeNow(5))
+                                                                       .endTime(ConverterHelper.dayBeforeNow(4))
+                                                                       .build());
     assertTrue(result.getData().size() > 0);
     assertTrue(result.getData().get(0).getTweetCount() > 0);
   }

--- a/src/test/java/com/github/redouane59/twitter/nrt/ITwitterClientV2Test.java
+++ b/src/test/java/com/github/redouane59/twitter/nrt/ITwitterClientV2Test.java
@@ -13,6 +13,7 @@ import com.github.redouane59.twitter.dto.tweet.TweetListV2;
 import com.github.redouane59.twitter.dto.tweet.TweetSearchResponse;
 import com.github.redouane59.twitter.dto.tweet.TweetType;
 import com.github.redouane59.twitter.dto.tweet.TweetV2;
+import com.github.redouane59.twitter.dto.tweet.TweetsCountsList;
 import com.github.redouane59.twitter.dto.user.User;
 import com.github.redouane59.twitter.dto.user.UserListV2;
 import com.github.redouane59.twitter.helpers.ConverterHelper;
@@ -295,6 +296,13 @@ public class ITwitterClientV2Test {
     assertNotNull(result.getData().get(0).getId());
     assertNotNull(result.getData().get(0).getText());
     assertNotNull(result.getData().get(0).getCreatedAt());
+  }
+
+  @Test
+  public void testGetTweetCount() {
+    TweetsCountsList result = twitterClient.getTweetsCounts("@Twitter");
+    assertTrue(result.getData().size() > 0);
+    assertTrue(result.getData().get(0).getTweetCount() > 0);
   }
 
 }

--- a/src/test/java/com/github/redouane59/twitter/nrt/ITwitterClientV2Test.java
+++ b/src/test/java/com/github/redouane59/twitter/nrt/ITwitterClientV2Test.java
@@ -319,8 +319,13 @@ public class ITwitterClientV2Test {
   }
 
   @Test
-  public void testGetTweetCountFullArchive() {
-    TweetsCountsList result = twitterClient.getTweetCountsFullArchive("@TwitterAPI");
+  public void testGetTweetCountFullArchiveWithParams() {
+    TweetsCountsList
+        result =
+        twitterClient.getTweetCountsFullArchive("@Twitter", AdditionnalParameters.builder()
+                                                                                 .startTime(ConverterHelper.dayBeforeNow(1000))
+                                                                                 .endTime(ConverterHelper.dayBeforeNow(30))
+                                                                                 .build());
     assertTrue(result.getData().size() > 0);
     assertTrue(result.getData().get(0).getTweetCount() > 0);
     assertNotNull(result.getMeta().getNextToken());

--- a/src/test/java/com/github/redouane59/twitter/nrt/ITwitterClientV2Test.java
+++ b/src/test/java/com/github/redouane59/twitter/nrt/ITwitterClientV2Test.java
@@ -301,7 +301,7 @@ public class ITwitterClientV2Test {
 
   @Test
   public void testGetTweetCount() {
-    TweetsCountsList result = twitterClient.getTweetsCounts("@Twitter");
+    TweetsCountsList result = twitterClient.getTweetCounts("@Twitter");
     assertTrue(result.getData().size() > 0);
     assertTrue(result.getData().get(0).getTweetCount() > 0);
   }
@@ -310,12 +310,21 @@ public class ITwitterClientV2Test {
   public void testGetTweetCountsWithParams() {
     TweetsCountsList
         result =
-        twitterClient.getTweetsCounts("@Twitter", AdditionnalParameters.builder()
-                                                                       .startTime(ConverterHelper.dayBeforeNow(5))
-                                                                       .endTime(ConverterHelper.dayBeforeNow(4))
-                                                                       .build());
+        twitterClient.getTweetCounts("@Twitter", AdditionnalParameters.builder()
+                                                                      .startTime(ConverterHelper.dayBeforeNow(5))
+                                                                      .endTime(ConverterHelper.dayBeforeNow(4))
+                                                                      .build());
     assertTrue(result.getData().size() > 0);
     assertTrue(result.getData().get(0).getTweetCount() > 0);
+  }
+
+  @Test
+  public void testGetTweetCountFullArchive() {
+    TweetsCountsList result = twitterClient.getTweetCountsFullArchive("@TwitterAPI");
+    assertTrue(result.getData().size() > 0);
+    assertTrue(result.getData().get(0).getTweetCount() > 0);
+    assertNotNull(result.getMeta().getNextToken());
+    assertTrue(result.getMeta().getTotalTweetCount() > 0);
   }
 
 }

--- a/src/test/java/com/github/redouane59/twitter/unit/UrlHelperTest.java
+++ b/src/test/java/com/github/redouane59/twitter/unit/UrlHelperTest.java
@@ -338,4 +338,9 @@ public class UrlHelperTest {
   public void testPostDmUrl() {
     assertEquals("https://api.twitter.com/1.1/direct_messages/events/new.json", urlHelper.getPostDmUrl());
   }
+
+  @Test
+  public void testGetTweetsCountsUrl() {
+    assertEquals("https://api.twitter.com/2/tweets/counts/recent", urlHelper.getTweetsCountsUrl());
+  }
 }

--- a/src/test/java/com/github/redouane59/twitter/unit/UrlHelperTest.java
+++ b/src/test/java/com/github/redouane59/twitter/unit/UrlHelperTest.java
@@ -343,4 +343,10 @@ public class UrlHelperTest {
   public void testGetTweetsCountsUrl() {
     assertEquals("https://api.twitter.com/2/tweets/counts/recent", urlHelper.getTweetsCountsUrl());
   }
+
+  @Test
+  public void testGetTweetsCountsAllUrl() {
+    assertEquals("https://api.twitter.com/2/tweets/counts/all", urlHelper.getTweetsCountsFullArchiveUrl());
+  }
+
 }


### PR DESCRIPTION
See https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-recent

Problematic : how to manage the additional parameters ? Each endpoint can have his own parameters combination. 
Ex:
- endpoint 1 will expect `query` (mandatory) + `startTime` & `endTime` (optional)
- endpoint 2 will expect `query` (mandatory) + `startTime`, `endTime`, and `nextToken` (optional)
- endpoint 3 will expect `tweetId` (mandatory) + `userId` (optional)
- etc etc.

I see 3 options : 
1/ Lots of constructors for each endpoint (as today). Really dirty and not agile
2/ As I started in this PR, a class `AdditionnalParameters` with a builder containing all the possible parameters endpoints can support. The user should use the ones related to the endpoint otherwise he will get errors.
3/ Create one parameter class with builders for each endpoint (i.e `TweetCountsParameters`, `GetTweetParameters` etc.) to avoid that users make errors and can only request expected parameters => looks to heavy.