### PR TITLE
#271: Add support for basic entities

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/Tweet.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/Tweet.java
@@ -1,5 +1,6 @@
 package io.github.redouane59.twitter.dto.tweet;
 
+import io.github.redouane59.twitter.dto.tweet.entities.Entities;
 import io.github.redouane59.twitter.dto.user.User;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -134,8 +135,14 @@ public interface Tweet {
    */
   Attachments getAttachments();
 
-  /*
+  /**
    * Get the source label of the tweet
    */
   String getSource();
+
+  /**
+   * Get the entities of the tweet
+   */
+  Entities getEntities();
+
 }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
@@ -3,6 +3,14 @@ package io.github.redouane59.twitter.dto.tweet;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.redouane59.twitter.dto.tweet.entities.BaseEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.Entities;
+import io.github.redouane59.twitter.dto.tweet.entities.HashtagEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.SymbolEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.TextBaseEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.UrlEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.UserMentionEntity;
 import io.github.redouane59.twitter.dto.user.UserV1;
 import io.github.redouane59.twitter.helpers.ConverterHelper;
 import java.time.LocalDateTime;
@@ -50,6 +58,7 @@ public class TweetV1 implements Tweet {
   private              String  inReplyToUserId;
   @JsonProperty("is_quote_status")
   private              boolean isQuoteStatus;
+  private              EntitiesV1     entities;
 
   @Override
   public LocalDateTime getCreatedAt() {
@@ -101,6 +110,11 @@ public class TweetV1 implements Tweet {
   }
 
   @Override
+  public Entities getEntities() {
+    return entities;
+  }
+
+  @Override
   public String getInReplyToStatusId(TweetType type) {
     return getInReplyToStatusId();
   }
@@ -111,5 +125,133 @@ public class TweetV1 implements Tweet {
       return null;
     }
     return user.getId();
+  }
+
+
+  @Getter
+  @Setter
+  public static class EntitiesV1 implements Entities {
+    @JsonProperty("hashtags")
+    private List<HashtagEntityV1> hashtags;
+    @JsonProperty("urls")
+    private List<UrlEntityV1> urls;
+    @JsonProperty("user_mentions")
+    private List<UserMentionEntityV1> userMentions;
+    @JsonProperty("symbols")
+    private List<SymbolEntityV1> symbols;
+    private JsonNode media; //TODO We should implement media objects accordingly
+  }
+
+  @Getter
+  @Setter
+  public static class BaseEntityV1 implements BaseEntity {
+    @JsonProperty("indices")
+    private int[] indices;
+
+    @Override
+    public int getStart() {
+      return indices[0];
+    }
+
+    @Override
+    public int getEnd() {
+      return indices[1];
+    }
+  }
+
+  @Getter
+  @Setter
+  public static class TextBaseEntityV1 extends BaseEntityV1 implements TextBaseEntity {
+    @JsonProperty("text")
+    private String text;
+
+    @Override
+    public String getText() {
+      return text;
+    }
+  }
+
+  @Getter
+  @Setter
+  public static class UrlEntityV1 extends BaseEntityV1 implements UrlEntity {
+    @JsonProperty("url")
+    private String url;
+    @JsonProperty("display_url")
+    private String displayUrl;
+    @JsonProperty("expanded_url")
+    private String expandedUrl;
+    @JsonProperty("unwound")
+    private UnwoundUrlEntity unwound;
+
+    @Override
+    public int getStatus() {
+      if(unwound != null) {
+        return unwound.getStatus();
+      }
+      return -1;
+    }
+
+    @Override
+    public String getDescription() {
+      if(unwound != null) {
+        return unwound.getDescription();
+      }
+      return null;
+    }
+
+    @Override
+    public String getTitle() {
+      if(unwound != null) {
+        return unwound.getTitle();
+      }
+      return null;
+    }
+
+    @Override
+    public String getUnwoundedUrl() {
+      if(unwound != null) {
+        return unwound.getUrl();
+      }
+      return null;
+    }
+  }
+
+  @Getter
+  @Setter
+  public static class UnwoundUrlEntity {
+    @JsonProperty("url")
+    private String url;
+    @JsonProperty("status")
+    private int status;
+    @JsonProperty("title")
+    private String title;
+    @JsonProperty("description")
+    private String description;
+  }
+
+  @Getter
+  @Setter
+  public static class HashtagEntityV1 extends TextBaseEntityV1 implements HashtagEntity{
+  }
+
+  @Getter
+  @Setter
+  public static class UserMentionEntityV1 extends TextBaseEntityV1 implements UserMentionEntity{
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("screen_name")
+    private String screenName;
+    @JsonProperty("id")
+    private long id;
+
+    @Override
+    public String getText() {
+      return getName();
+    }
+  }
+
+  @Getter
+  @Setter
+  public static class SymbolEntityV1 extends TextBaseEntityV1 implements SymbolEntity{
   }
 }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
@@ -169,7 +169,6 @@ public class TweetV1 implements Tweet {
     private String displayUrl;
     @JsonProperty("expanded_url")
     private String expandedUrl;
-    @JsonProperty("unwound")
     private UnwoundUrlEntity unwound;
 
     @Override

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
@@ -110,11 +110,6 @@ public class TweetV1 implements Tweet {
   }
 
   @Override
-  public Entities getEntities() {
-    return entities;
-  }
-
-  @Override
   public String getInReplyToStatusId(TweetType type) {
     return getInReplyToStatusId();
   }
@@ -131,13 +126,10 @@ public class TweetV1 implements Tweet {
   @Getter
   @Setter
   public static class EntitiesV1 implements Entities {
-    @JsonProperty("hashtags")
     private List<HashtagEntityV1> hashtags;
-    @JsonProperty("urls")
     private List<UrlEntityV1> urls;
     @JsonProperty("user_mentions")
     private List<UserMentionEntityV1> userMentions;
-    @JsonProperty("symbols")
     private List<SymbolEntityV1> symbols;
     private JsonNode media; //TODO We should implement media objects accordingly
   }
@@ -145,7 +137,6 @@ public class TweetV1 implements Tweet {
   @Getter
   @Setter
   public static class BaseEntityV1 implements BaseEntity {
-    @JsonProperty("indices")
     private int[] indices;
 
     @Override
@@ -162,7 +153,6 @@ public class TweetV1 implements Tweet {
   @Getter
   @Setter
   public static class TextBaseEntityV1 extends BaseEntityV1 implements TextBaseEntity {
-    @JsonProperty("text")
     private String text;
 
     @Override
@@ -174,7 +164,6 @@ public class TweetV1 implements Tweet {
   @Getter
   @Setter
   public static class UrlEntityV1 extends BaseEntityV1 implements UrlEntity {
-    @JsonProperty("url")
     private String url;
     @JsonProperty("display_url")
     private String displayUrl;
@@ -219,13 +208,9 @@ public class TweetV1 implements Tweet {
   @Getter
   @Setter
   public static class UnwoundUrlEntity {
-    @JsonProperty("url")
     private String url;
-    @JsonProperty("status")
     private int status;
-    @JsonProperty("title")
     private String title;
-    @JsonProperty("description")
     private String description;
   }
 
@@ -237,11 +222,9 @@ public class TweetV1 implements Tweet {
   @Getter
   @Setter
   public static class UserMentionEntityV1 extends TextBaseEntityV1 implements UserMentionEntity{
-    @JsonProperty("name")
     private String name;
     @JsonProperty("screen_name")
     private String screenName;
-    @JsonProperty("id")
     private long id;
 
     @Override

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
@@ -370,9 +370,7 @@ public class TweetV2 implements Tweet {
   @Setter
   public static class EntitiesV2 implements Entities {
 
-    @JsonProperty("hashtags")
     private List<HashtagEntityV2> hashtags;
-    @JsonProperty("urls")
     private List<UrlEntityV2> urls;
     @JsonProperty("mentions")
     private List<UserMentionEntityV2> userMentions;
@@ -383,16 +381,13 @@ public class TweetV2 implements Tweet {
   @Getter
   @Setter
   public static class BaseEntityV2 implements BaseEntity {
-    @JsonProperty("start")
     private int start;
-    @JsonProperty("end")
     private int end;
   }
 
   @Getter
   @Setter
   public static class TextBaseEntityV2 extends BaseEntityV2 implements TextBaseEntity {
-    @JsonProperty("tag")
     private String tag;
 
     @Override
@@ -404,17 +399,13 @@ public class TweetV2 implements Tweet {
   @Getter
   @Setter
   public static class UrlEntityV2 extends BaseEntityV2 implements UrlEntity {
-    @JsonProperty("url")
     private String url;
     @JsonProperty("display_url")
     private String displayUrl;
     @JsonProperty("expanded_url")
     private String expandedUrl;
-    @JsonProperty("status")
     private int status;
-    @JsonProperty("description")
     private String description;
-    @JsonProperty("title")
     private String title;
     @JsonProperty("unwound_url")
     private String unwoundedUrl;
@@ -428,7 +419,6 @@ public class TweetV2 implements Tweet {
   @Getter
   @Setter
   public static class UserMentionEntityV2 extends TextBaseEntityV2 implements UserMentionEntity{
-    @JsonProperty("username")
     private String username;
 
     @Override

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
@@ -428,6 +428,18 @@ public class TweetV2 implements Tweet {
   @Getter
   @Setter
   public static class UserMentionEntityV2 extends TextBaseEntityV2 implements UserMentionEntity{
+    @JsonProperty("username")
+    private String username;
+
+    @Override
+    public String getText() {
+      return getUsername();
+    }
+
+    @Override
+    public String getTag() {
+      return getUsername();
+    }
   }
 
   @Getter

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
@@ -239,7 +239,6 @@ public class TweetV2 implements Tweet {
     private String                   inReplyToUserId;
     @JsonProperty("referenced_tweets")
     private List<ReferencedTweetDTO> referencedTweets;
-    @JsonProperty("entities")
     private EntitiesV2 entities;
     @JsonProperty("public_metrics")
     @JsonInclude(Include.NON_NULL)

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
@@ -7,6 +7,13 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.redouane59.twitter.dto.stream.StreamRules;
+import io.github.redouane59.twitter.dto.tweet.entities.BaseEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.Entities;
+import io.github.redouane59.twitter.dto.tweet.entities.HashtagEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.SymbolEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.TextBaseEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.UrlEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.UserMentionEntity;
 import io.github.redouane59.twitter.dto.user.User;
 import io.github.redouane59.twitter.dto.user.UserV2;
 import io.github.redouane59.twitter.helpers.ConverterHelper;
@@ -18,6 +25,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @version labs
@@ -27,8 +35,10 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Slf4j
 public class TweetV2 implements Tweet {
 
+  private static final String  NOT_IMPLEMENTED_EXECEPTION = "not implemented";
   private TweetData                data;
   private Includes                 includes;
   @JsonProperty("matching_rules")
@@ -117,6 +127,14 @@ public class TweetV2 implements Tweet {
       return null;
     }
     return data.getSource();
+  }
+
+  @Override
+  public Entities getEntities() {
+    if (data == null) {
+      return null;
+    }
+    return data.getEntities();
   }
 
   @Override
@@ -221,7 +239,8 @@ public class TweetV2 implements Tweet {
     private String                   inReplyToUserId;
     @JsonProperty("referenced_tweets")
     private List<ReferencedTweetDTO> referencedTweets;
-    private JsonNode                 entities;
+    @JsonProperty("entities")
+    private EntitiesV2 entities;
     @JsonProperty("public_metrics")
     @JsonInclude(Include.NON_NULL)
     private TweetPublicMetricsDTO    publicMetrics;
@@ -330,6 +349,7 @@ public class TweetV2 implements Tweet {
 
     private List<UserV2.UserData>   users;
     private List<TweetV2.TweetData> tweets;
+    private JsonNode media; //TODO We should implement media objects accordingly
   }
 
 
@@ -347,4 +367,72 @@ public class TweetV2 implements Tweet {
     private int quoteCount;
   }
 
+  @Getter
+  @Setter
+  public static class EntitiesV2 implements Entities {
+
+    @JsonProperty("hashtags")
+    private List<HashtagEntityV2> hashtags;
+    @JsonProperty("urls")
+    private List<UrlEntityV2> urls;
+    @JsonProperty("mentions")
+    private List<UserMentionEntityV2> userMentions;
+    @JsonProperty("cashtags")
+    private List<CashtagEntityV2> symbols;
+  }
+
+  @Getter
+  @Setter
+  public static class BaseEntityV2 implements BaseEntity {
+    @JsonProperty("start")
+    private int start;
+    @JsonProperty("end")
+    private int end;
+  }
+
+  @Getter
+  @Setter
+  public static class TextBaseEntityV2 extends BaseEntityV2 implements TextBaseEntity {
+    @JsonProperty("tag")
+    private String tag;
+
+    @Override
+    public String getText() {
+      return tag;
+    }
+  }
+
+  @Getter
+  @Setter
+  public static class UrlEntityV2 extends BaseEntityV2 implements UrlEntity {
+    @JsonProperty("url")
+    private String url;
+    @JsonProperty("display_url")
+    private String displayUrl;
+    @JsonProperty("expanded_url")
+    private String expandedUrl;
+    @JsonProperty("status")
+    private int status;
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("title")
+    private String title;
+    @JsonProperty("unwound_url")
+    private String unwoundedUrl;
+  }
+
+  @Getter
+  @Setter
+  public static class HashtagEntityV2 extends TextBaseEntityV2 implements HashtagEntity{
+  }
+
+  @Getter
+  @Setter
+  public static class UserMentionEntityV2 extends TextBaseEntityV2 implements UserMentionEntity{
+  }
+
+  @Getter
+  @Setter
+  public static class CashtagEntityV2 extends TextBaseEntityV2 implements SymbolEntity{
+  }
 }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/BaseEntity.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/BaseEntity.java
@@ -1,0 +1,7 @@
+package io.github.redouane59.twitter.dto.tweet.entities;
+
+public interface BaseEntity {
+
+    int getStart();
+    int getEnd();
+}

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/Entities.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/Entities.java
@@ -1,0 +1,10 @@
+package io.github.redouane59.twitter.dto.tweet.entities;
+
+import java.util.List;
+
+public interface Entities {
+   List<? extends HashtagEntity> getHashtags();
+   List<? extends UrlEntity> getUrls();
+   List<? extends SymbolEntity> getSymbols();
+   List<? extends UserMentionEntity> getUserMentions();
+}

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/HashtagEntity.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/HashtagEntity.java
@@ -1,0 +1,5 @@
+package io.github.redouane59.twitter.dto.tweet.entities;
+
+public interface HashtagEntity extends TextBaseEntity{
+
+}

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/SymbolEntity.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/SymbolEntity.java
@@ -1,0 +1,4 @@
+package io.github.redouane59.twitter.dto.tweet.entities;
+
+public interface SymbolEntity extends TextBaseEntity {
+}

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/TextBaseEntity.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/TextBaseEntity.java
@@ -1,0 +1,5 @@
+package io.github.redouane59.twitter.dto.tweet.entities;
+
+public interface TextBaseEntity extends BaseEntity {
+    String getText();
+}

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/UrlEntity.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/UrlEntity.java
@@ -1,0 +1,11 @@
+package io.github.redouane59.twitter.dto.tweet.entities;
+
+public interface UrlEntity extends BaseEntity {
+    String getUrl();
+    String getDisplayUrl();
+    String getExpandedUrl();
+    int getStatus();
+    String getDescription();
+    String getTitle();
+    String getUnwoundedUrl();
+}

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/UserMentionEntity.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/UserMentionEntity.java
@@ -1,0 +1,4 @@
+package io.github.redouane59.twitter.dto.tweet.entities;
+
+public interface UserMentionEntity extends TextBaseEntity {
+}

--- a/src/test/java/io/github/redouane59/twitter/unit/TweetDeserializerV1Test.java
+++ b/src/test/java/io/github/redouane59/twitter/unit/TweetDeserializerV1Test.java
@@ -6,9 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import io.github.redouane59.twitter.TwitterClient;
 import io.github.redouane59.twitter.dto.tweet.Tweet;
 import io.github.redouane59.twitter.dto.tweet.TweetV1;
+import io.github.redouane59.twitter.dto.tweet.TweetV2;
+import io.github.redouane59.twitter.dto.tweet.entities.Entities;
+import io.github.redouane59.twitter.dto.tweet.entities.HashtagEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.SymbolEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.UrlEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.UserMentionEntity;
 import io.github.redouane59.twitter.helpers.ConverterHelper;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 public class TweetDeserializerV1Test {
@@ -74,5 +82,56 @@ public class TweetDeserializerV1Test {
     assertEquals(392, tweetV1.getUser().getFollowingCount());
     assertEquals(83425, tweetV1.getUser().getTweetCount());
     assertEquals(ConverterHelper.getDateFromTwitterString("Sun Jul 29 13:24:02 +0000 2012"), tweetV1.getUser().getDateOfCreation());
+  }
+  @Test
+  public void testEntities() {
+    Entities entities = tweetV1.getEntities();
+    assertNotNull(entities);
+
+    List<? extends SymbolEntity> cashtags = entities.getSymbols();
+    assertNotNull(cashtags);
+    assertEquals(1,cashtags.size());
+
+    SymbolEntity e = cashtags.get(0);
+    assertNotNull(e);
+    assertEquals(12, e.getStart());
+    assertEquals(17, e.getEnd());
+    assertEquals("twtr", e.getText());
+
+    List<? extends HashtagEntity> hashtags = entities.getHashtags();
+    assertNotNull(hashtags);
+    assertEquals(1,hashtags.size());
+
+    HashtagEntity h = hashtags.get(0);
+    assertNotNull(h);
+    assertEquals(178, h.getStart());
+    assertEquals(189, h.getEnd());
+    assertEquals("TwitterAPI", h.getText());
+
+    List<? extends UserMentionEntity> mentions = entities.getUserMentions();
+    assertNotNull(mentions);
+    assertEquals(1,mentions.size());
+
+    TweetV1.UserMentionEntityV1 m = (TweetV1.UserMentionEntityV1) mentions.get(0);
+    assertNotNull(m);
+    assertEquals(8, m.getStart());
+    assertEquals(19, m.getEnd());
+    assertEquals("Penn Med CDH", m.getName());
+    assertEquals("PennMedCDH", m.getScreenName());
+    assertEquals(1615654896, m.getId());
+
+    List<? extends UrlEntity> urls = entities.getUrls();
+    UrlEntity u = urls.get(0);
+    assertNotNull(u);
+    assertEquals(62, u.getStart());
+    assertEquals(85, u.getEnd());
+    assertEquals("https://t.co/D0n7a53c2l", u.getUrl());
+    assertEquals("http://bit.ly/18gECvy", u.getExpandedUrl());
+    assertEquals("https://www.youtube.com/watch?v=oHg5SJYRHA0", u.getUnwoundedUrl());
+    assertEquals("bit.ly/18gECvy", u.getDisplayUrl());
+    assertEquals(200, u.getStatus());
+    assertEquals("http://www.facebook.com/rickroll548 As long as trolls are still trolling, the Rick will never stop rolling.", u.getDescription());
+    assertEquals("RickRoll'D", u.getTitle());
+
   }
 }

--- a/src/test/java/io/github/redouane59/twitter/unit/TweetDeserializerV2Test.java
+++ b/src/test/java/io/github/redouane59/twitter/unit/TweetDeserializerV2Test.java
@@ -5,11 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.redouane59.twitter.TwitterClient;
 import io.github.redouane59.twitter.dto.tweet.ContextAnnotation;
+import io.github.redouane59.twitter.dto.tweet.entities.HashtagEntity;
 import io.github.redouane59.twitter.dto.tweet.ReplySettings;
+import io.github.redouane59.twitter.dto.tweet.entities.SymbolEntity;
 import io.github.redouane59.twitter.dto.tweet.Tweet;
 import io.github.redouane59.twitter.dto.tweet.TweetV2;
+import io.github.redouane59.twitter.dto.tweet.entities.UrlEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.UserMentionEntity;
 import io.github.redouane59.twitter.dto.user.User;
 import io.github.redouane59.twitter.helpers.ConverterHelper;
 import java.io.File;
@@ -140,5 +145,69 @@ public class TweetDeserializerV2Test {
     String tweetAsString = TwitterClient.OBJECT_MAPPER.writeValueAsString(tweetv2);
     assertNotNull(tweetAsString);
     assertTrue(tweetAsString.contains("Try to use some function"));
+  }
+
+  @Test
+  public void testIncludesMedia() {
+    TweetV2 tweet = (TweetV2) tweetv2;
+    JsonNode media = tweet.getIncludes().getMedia();
+    assertNotNull(media);
+  }
+
+  @Test
+  public void testEntities() {
+    TweetV2 tweet = (TweetV2) tweetv2;
+    TweetV2.EntitiesV2 entities = tweet.getData().getEntities();
+    assertNotNull(entities);
+
+    List<? extends SymbolEntity> cashtags = entities.getSymbols();
+    assertNotNull(cashtags);
+    assertEquals(1,cashtags.size());
+
+    SymbolEntity e = cashtags.get(0);
+    assertNotNull(e);
+    assertEquals(18, e.getStart());
+    assertEquals(23, e.getEnd());
+    assertEquals("twtr", e.getText());
+
+    List<? extends HashtagEntity> hashtags = entities.getHashtags();
+    assertNotNull(hashtags);
+    assertEquals(1,hashtags.size());
+
+    HashtagEntity h = hashtags.get(0);
+    assertNotNull(h);
+    assertEquals(0, h.getStart());
+    assertEquals(17, h.getEnd());
+    assertEquals("blacklivesmatter", h.getText());
+
+    List<? extends UserMentionEntity> mentions = entities.getUserMentions();
+    assertNotNull(mentions);
+    assertEquals(2,mentions.size());
+
+    UserMentionEntity m = mentions.get(0);
+    assertNotNull(m);
+    assertEquals(0, m.getStart());
+    assertEquals(13, m.getEnd());
+    assertEquals("RedouaneBali", m.getText());
+
+    m = mentions.get(1);
+    assertNotNull(m);
+    assertEquals(14, m.getStart());
+    assertEquals(25, m.getEnd());
+    assertEquals("TwitterAPI", m.getText());
+
+    List<? extends UrlEntity> urls = entities.getUrls();
+    UrlEntity u = urls.get(0);
+    assertNotNull(u);
+    assertEquals(44, u.getStart());
+    assertEquals(67, u.getEnd());
+    assertEquals("https://t.co/crkYRdjUB0", u.getUrl());
+    assertEquals("https://twitter.com", u.getExpandedUrl());
+    assertEquals("https://twitter.com", u.getUnwoundedUrl());
+    assertEquals("twitter.com", u.getDisplayUrl());
+    assertEquals(200, u.getStatus());
+    assertEquals("From breaking news and entertainment to sports and politics, get the full story with all the live commentary.", u.getDescription());
+    assertEquals("bird", u.getTitle());
+
   }
 }

--- a/src/test/resources/tests/tweet_example_v1.json
+++ b/src/test/resources/tests/tweet_example_v1.json
@@ -64,7 +64,55 @@
       "reply_count":3,
       "retweet_count":2,
       "favorite_count":1,
-      "entities":{  },
+      "entities": {
+        "hashtags": [
+          {
+            "text": "TwitterAPI",
+            "indices": [
+              178,
+              189
+            ]
+          }
+        ],
+        "symbols": [
+          {
+            "indices": [
+              12,
+              17
+            ],
+            "text": "twtr"
+          }
+        ],
+        "user_mentions": [
+          {
+            "screen_name": "PennMedCDH",
+            "name": "Penn Med CDH",
+            "id": 1615654896,
+            "id_str": "1615654896",
+            "indices": [
+              8,
+              19
+            ]
+          }
+        ],
+        "urls": [
+          {
+            "url": "https://t.co/D0n7a53c2l",
+            "expanded_url": "http://bit.ly/18gECvy",
+            "display_url": "bit.ly/18gECvy",
+            "unwound": {
+              "url": "https://www.youtube.com/watch?v=oHg5SJYRHA0",
+              "status": 200,
+              "title": "RickRoll'D",
+              "description": "http://www.facebook.com/rickroll548 As long as trolls are still trolling, the Rick will never stop rolling."
+            },
+            "indices": [
+              62,
+              85
+            ]
+          }
+        ]
+      },
       "favorited":false,
       "retweeted":false,
       "filter_level":"low",

--- a/src/test/resources/tests/tweet_example_v2.json
+++ b/src/test/resources/tests/tweet_example_v2.json
@@ -23,16 +23,43 @@
       }
     ],
     "entities": {
+      "cashtags": [
+        {
+          "start": 18,
+          "end": 23,
+          "tag": "twtr"
+        }
+      ],
+      "hashtags": [
+        {
+          "start": 0,
+          "end": 17,
+          "tag": "blacklivesmatter"
+        }
+      ],
       "mentions": [
         {
           "start": 0,
           "end": 13,
-          "username": "RedouaneBali"
+          "tag": "RedouaneBali"
         },
         {
           "start": 14,
           "end": 25,
-          "username": "TwitterAPI"
+          "tag": "TwitterAPI"
+        }
+      ],
+      "urls": [
+        {
+          "start": 44,
+          "end": 67,
+          "url": "https://t.co/crkYRdjUB0",
+          "expanded_url": "https://twitter.com",
+          "display_url": "twitter.com",
+          "status": "200",
+          "title": "bird",
+          "description": "From breaking news and entertainment to sports and politics, get the full story with all the live commentary.",
+          "unwound_url": "https://twitter.com"
         }
       ]
     },
@@ -79,6 +106,19 @@
     }
   },
   "includes": {
+    "media": [
+      {
+        "height": 720,
+        "duration_ms": 34875,
+        "media_key": "3_1365362339449561088",
+        "type": "video",
+        "preview_image_url": "https://pbs.twimg.com/ext_tw_video_thumb/1293565706408038401/pu/img/66P2dvbU4a02jYbV.jpg",
+        "public_metrics": {
+          "view_count": 279438
+        },
+        "width": 1280
+      }
+    ],
     "users": [
       {
         "protected": false,

--- a/src/test/resources/tests/tweet_example_v2.json
+++ b/src/test/resources/tests/tweet_example_v2.json
@@ -41,12 +41,12 @@
         {
           "start": 0,
           "end": 13,
-          "tag": "RedouaneBali"
+          "username": "RedouaneBali"
         },
         {
           "start": 14,
           "end": 25,
-          "tag": "TwitterAPI"
+          "username": "TwitterAPI"
         }
       ],
       "urls": [


### PR DESCRIPTION
# What does this PR do?

- Adds support for basic entities (hashtags, cashtags, mentions, urls) in V1 and V2 tweet objects.