### PR TITLE
Adds support to retrieve basic media entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
       <email>bali.redouane@gmail.com</email>
       <name>Redouane Bali</name>
       <organization>Redouane59</organization>
-      <organizationUrl>http://github.com/Redouane59</organizationUrl>
+      <organizationUrl>https://github.com/Redouane59</organizationUrl>
     </developer>
   </developers>
   <distributionManagement>
@@ -149,7 +149,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 
@@ -177,10 +177,10 @@
     <connection>scm:git:git://github.com/Redouane59/twittered.git</connection>
     <developerConnection>scm:git:ssh://github.com:Redouane59/twittered.git
     </developerConnection>
-    <url>http://github.com/Redouane59/twittered</url>
+    <url>https://github.com/Redouane59/twittered</url>
   </scm>
 
-  <url>http://github.com/Redouane59/twittered</url>
+  <url>https://github.com/Redouane59/twittered</url>
 
-  <version>2.7</version>
+  <version>2.7-SNAPSHOT</version>
 </project>

--- a/src/main/java/io/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/io/github/redouane59/twitter/TwitterClient.java
@@ -94,10 +94,12 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   public static final  String             EXPANSION                            = "expansions";
   public static final  String
                                           ALL_EXPANSIONS                       =
-      "author_id,entities.mentions.username,in_reply_to_user_id,referenced_tweets.id,referenced_tweets.id.author_id";
+      "author_id,entities.mentions.username,in_reply_to_user_id,referenced_tweets.id,referenced_tweets.id.author_id,attachments.media_keys";
   public static final  String             USER_FIELDS                          = "user.fields";
   public static final  String             ALL_USER_FIELDS                      =
       "id,created_at,entities,username,name,location,url,verified,profile_image_url,public_metrics,pinned_tweet_id,description,protected";
+  public static final  String             MEDIA_FIELD                          = "media.fields";
+  public static final  String ALL_MEDIA_FIELDS = "duration_ms,height,media_key,preview_image_url,public_metrics,type,url,width";
   private static final String             QUERY                                = "query";
   private static final String             CURSOR                               = "cursor";
   private static final String             NEXT                                 = "next";
@@ -552,6 +554,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(EXPANSION, ALL_EXPANSIONS);
     parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     return getRequestHelper().getRequestWithParameters(url, parameters, TweetV2.class).orElseThrow(NoSuchElementException::new);
   }
 
@@ -562,6 +565,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(EXPANSION, ALL_EXPANSIONS);
     parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     StringBuilder result = new StringBuilder();
     int           i      = 0;
     while (i < tweetIds.size() && i < URLHelper.MAX_LOOKUP) {
@@ -600,6 +604,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(QUERY, query);
     parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
     parameters.put(EXPANSION, ALL_EXPANSIONS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     String url = urlHelper.getSearchRecentTweetsUrl();
     if (!additionalParameters.isRecursiveCall()) {
       return getRequestHelper().getRequestWithParameters(url, parameters, TweetList.class).orElseThrow(NoSuchElementException::new);
@@ -626,6 +631,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
       parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS.replace(",context_annotations", ""));
     }
     parameters.put(EXPANSION, ALL_EXPANSIONS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     String url = urlHelper.getSearchAllTweetsUrl();
     if (!additionalParameters.isRecursiveCall()) {
       return getRequestHelperV2().getRequestWithParameters(url, parameters, TweetList.class).orElseThrow(NoSuchElementException::new);
@@ -758,6 +764,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(EXPANSION, ALL_EXPANSIONS);
     parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     return requestHelperV2.getAsyncRequest(url, parameters, consumer);
   }
 
@@ -773,6 +780,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(EXPANSION, ALL_EXPANSIONS);
     parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     if (backfillMinutes > 0) {
       parameters.put(BACKFILL_MINUTES, String.valueOf(backfillMinutes));
     }
@@ -841,6 +849,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(EXPANSION, ALL_EXPANSIONS);
     parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     return requestHelperV2.getAsyncRequest(url, parameters, consumer);
   }
 
@@ -856,6 +865,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(EXPANSION, ALL_EXPANSIONS);
     parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     if (backfillMinutes > 0) {
       parameters.put(BACKFILL_MINUTES, String.valueOf(backfillMinutes));
     }
@@ -1047,7 +1057,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
           DmEvent.builder().event(new DirectMessage(text, userId)).build());
       return getRequestHelperV1().postRequestWithBodyJson(url, null, body, DmEvent.class).orElseThrow(NoSuchElementException::new);
     } catch (JsonProcessingException e) {
-      LOGGER.error(e.getMessage(), e.getStackTrace());
+      LOGGER.error(e.getMessage(), e);
     }
     return null;
   }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/Tweet.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/Tweet.java
@@ -1,6 +1,7 @@
 package io.github.redouane59.twitter.dto.tweet;
 
 import io.github.redouane59.twitter.dto.tweet.entities.Entities;
+import io.github.redouane59.twitter.dto.tweet.entities.MediaEntity;
 import io.github.redouane59.twitter.dto.user.User;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -144,5 +145,10 @@ public interface Tweet {
    * Get the entities of the tweet
    */
   Entities getEntities();
+
+  /**
+   * Get the {@link MediaEntity media entities} of the tweet
+   */
+  List<? extends MediaEntity> getMedia();
 
 }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
@@ -15,6 +15,7 @@ import io.github.redouane59.twitter.dto.user.UserV1;
 import io.github.redouane59.twitter.helpers.ConverterHelper;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -115,7 +116,7 @@ public class TweetV1 implements Tweet {
     if(entities != null) {
       return entities.getMedia();
     }
-    return null;
+    return Collections.emptyList();
   }
 
   @Override

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
@@ -3,10 +3,10 @@ package io.github.redouane59.twitter.dto.tweet;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.github.redouane59.twitter.dto.tweet.entities.BaseEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.Entities;
 import io.github.redouane59.twitter.dto.tweet.entities.HashtagEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.MediaEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.SymbolEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.TextBaseEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.UrlEntity;
@@ -16,6 +16,8 @@ import io.github.redouane59.twitter.helpers.ConverterHelper;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TweetV1 implements Tweet {
 
-  private static final String  NOT_IMPLEMENTED_EXECEPTION = "not implemented";
+  private static final String NOT_IMPLEMENTED_EXCEPTION = "not implemented";
   private              String  id;
   private              String  lang;
   @JsonProperty("retweet_count")
@@ -67,7 +69,7 @@ public class TweetV1 implements Tweet {
 
   @Override
   public List<ContextAnnotation> getContextAnnotations() {
-    LOGGER.error(NOT_IMPLEMENTED_EXECEPTION);
+    LOGGER.error(NOT_IMPLEMENTED_EXCEPTION);
     return Arrays.asList();
   }
 
@@ -81,31 +83,38 @@ public class TweetV1 implements Tweet {
 
   @Override
   public String getConversationId() {
-    LOGGER.error(NOT_IMPLEMENTED_EXECEPTION);
+    LOGGER.error(NOT_IMPLEMENTED_EXCEPTION);
     return null;
   }
 
   @Override
   public ReplySettings getReplySettings() {
-    LOGGER.error(NOT_IMPLEMENTED_EXECEPTION);
+    LOGGER.error(NOT_IMPLEMENTED_EXCEPTION);
     return null;
   }
 
   @Override
   public Geo getGeo() {
-    LOGGER.error(NOT_IMPLEMENTED_EXECEPTION);
+    LOGGER.error(NOT_IMPLEMENTED_EXCEPTION);
     return new Geo();
   }
 
   @Override
   public Attachments getAttachments() {
-    LOGGER.error(NOT_IMPLEMENTED_EXECEPTION);
+    LOGGER.error(NOT_IMPLEMENTED_EXCEPTION);
     return new Attachments();
   }
 
   @Override
   public String getSource() {
-    LOGGER.error(NOT_IMPLEMENTED_EXECEPTION);
+    LOGGER.error(NOT_IMPLEMENTED_EXCEPTION);
+    return null;
+  }
+  @Override
+  public List<MediaEntityV1> getMedia() {
+    if(entities != null) {
+      return entities.getMedia();
+    }
     return null;
   }
 
@@ -131,7 +140,7 @@ public class TweetV1 implements Tweet {
     @JsonProperty("user_mentions")
     private List<UserMentionEntityV1> userMentions;
     private List<SymbolEntityV1> symbols;
-    private JsonNode media; //TODO We should implement media objects accordingly
+    private List<MediaEntityV1> media;
   }
 
   @Getter
@@ -235,5 +244,30 @@ public class TweetV1 implements Tweet {
   @Getter
   @Setter
   public static class SymbolEntityV1 extends TextBaseEntityV1 implements SymbolEntity{
+  }
+
+  @Getter
+  @Setter
+  public static class MediaEntityV1 extends BaseEntityV1 implements MediaEntity {
+   private long id;
+   private String url;
+   @JsonProperty("display_url")
+   private String displayUrl;
+   @JsonProperty("expanded_url")
+   private String expandedUrl;
+   @JsonProperty("media_url_https")
+   private String mediaUrl;
+   private String type;
+   private Map<String, MediaSize> sizes;
+  }
+
+  @Getter
+  @Setter
+  public static class MediaSize {
+    @JsonProperty("w")
+    private int width;
+    @JsonProperty("h")
+    private int height;
+    private String resize;
   }
 }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.github.redouane59.twitter.dto.stream.StreamRules;
 import io.github.redouane59.twitter.dto.tweet.entities.BaseEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.Entities;
 import io.github.redouane59.twitter.dto.tweet.entities.HashtagEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.MediaEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.SymbolEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.TextBaseEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.UrlEntity;
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TweetV2 implements Tweet {
 
-  private static final String  NOT_IMPLEMENTED_EXECEPTION = "not implemented";
+  private static final String  NOT_IMPLEMENTED_EXCEPTION = "not implemented";
   private TweetData                data;
   private Includes                 includes;
   @JsonProperty("matching_rules")
@@ -135,6 +135,14 @@ public class TweetV2 implements Tweet {
       return null;
     }
     return data.getEntities();
+  }
+
+  @Override
+  public List<MediaEntityV2> getMedia() {
+    if (includes == null) {
+      return null;
+    }
+    return includes.getMedia();
   }
 
   @Override
@@ -314,6 +322,12 @@ public class TweetV2 implements Tweet {
     }
 
     @Override
+    public List<MediaEntityV2> getMedia() {
+      LOGGER.error(NOT_IMPLEMENTED_EXCEPTION);
+      return null;
+    }
+
+    @Override
     @JsonIgnore
     public User getUser() {
       throw new UnsupportedOperationException();
@@ -348,7 +362,7 @@ public class TweetV2 implements Tweet {
 
     private List<UserV2.UserData>   users;
     private List<TweetV2.TweetData> tweets;
-    private JsonNode media; //TODO We should implement media objects accordingly
+    private List<TweetV2.MediaEntityV2> media;
   }
 
 
@@ -376,6 +390,7 @@ public class TweetV2 implements Tweet {
     private List<UserMentionEntityV2> userMentions;
     @JsonProperty("cashtags")
     private List<CashtagEntityV2> symbols;
+
   }
 
   @Getter
@@ -435,5 +450,64 @@ public class TweetV2 implements Tweet {
   @Getter
   @Setter
   public static class CashtagEntityV2 extends TextBaseEntityV2 implements SymbolEntity{
+  }
+
+  @Getter
+  @Setter
+  public static class MediaEntityV2 implements MediaEntity {
+
+    @JsonProperty("media_key")
+    private String key;
+    private String type;
+    @JsonProperty("duration_ms")
+    private int duration;
+    private int height;
+    private int width;
+    private String url;
+    @JsonProperty("preview_image_url")
+    private String previewImageUrl;
+    @JsonProperty("public_metrics")
+    private MediaPublicMetricsDTO publicMetrics;
+
+    @Override
+    public int getStart() {
+      LOGGER.info(NOT_IMPLEMENTED_EXCEPTION);
+      return -1;
+    }
+
+    @Override
+    public int getEnd() {
+      LOGGER.info(NOT_IMPLEMENTED_EXCEPTION);
+      return -1;
+    }
+
+    @Override
+    public String getDisplayUrl() {
+      return getUrl();
+    }
+
+    @Override
+    public String getExpandedUrl() {
+      return getUrl();
+    }
+
+    @Override
+    public String getMediaUrl() {
+      return getUrl();
+    }
+
+    @Override
+    public long getId() {
+      LOGGER.info(NOT_IMPLEMENTED_EXCEPTION);
+      return -1;
+    }
+  }
+
+  @Getter
+  @Setter
+  public static class MediaPublicMetricsDTO {
+
+    @JsonProperty("view_count")
+    private int viewCount;
   }
 }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
@@ -18,7 +18,7 @@ import io.github.redouane59.twitter.dto.user.User;
 import io.github.redouane59.twitter.dto.user.UserV2;
 import io.github.redouane59.twitter.helpers.ConverterHelper;
 import java.time.LocalDateTime;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -140,7 +140,7 @@ public class TweetV2 implements Tweet {
   @Override
   public List<MediaEntityV2> getMedia() {
     if (includes == null) {
-      return null;
+      return Collections.emptyList();
     }
     return includes.getMedia();
   }
@@ -212,7 +212,7 @@ public class TweetV2 implements Tweet {
   @Override
   public List<ContextAnnotation> getContextAnnotations() {
     if (data == null) {
-      return Arrays.asList();
+      return Collections.emptyList();
     }
     return data.getContextAnnotations();
   }
@@ -324,7 +324,7 @@ public class TweetV2 implements Tweet {
     @Override
     public List<MediaEntityV2> getMedia() {
       LOGGER.error(NOT_IMPLEMENTED_EXCEPTION);
-      return null;
+      return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/MediaEntity.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/entities/MediaEntity.java
@@ -1,0 +1,11 @@
+package io.github.redouane59.twitter.dto.tweet.entities;
+
+public interface MediaEntity extends BaseEntity{
+
+    String getDisplayUrl();
+    String getExpandedUrl();
+    String getMediaUrl();
+    String getType();
+    String getUrl();
+    long getId();
+}

--- a/src/test/java/io/github/redouane59/twitter/unit/TweetDeserializerV1Test.java
+++ b/src/test/java/io/github/redouane59/twitter/unit/TweetDeserializerV1Test.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import io.github.redouane59.twitter.TwitterClient;
 import io.github.redouane59.twitter.dto.tweet.Tweet;
 import io.github.redouane59.twitter.dto.tweet.TweetV1;
-import io.github.redouane59.twitter.dto.tweet.TweetV2;
 import io.github.redouane59.twitter.dto.tweet.entities.Entities;
 import io.github.redouane59.twitter.dto.tweet.entities.HashtagEntity;
+import io.github.redouane59.twitter.dto.tweet.entities.MediaEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.SymbolEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.UrlEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.UserMentionEntity;
@@ -16,6 +16,7 @@ import io.github.redouane59.twitter.helpers.ConverterHelper;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -83,6 +84,7 @@ public class TweetDeserializerV1Test {
     assertEquals(83425, tweetV1.getUser().getTweetCount());
     assertEquals(ConverterHelper.getDateFromTwitterString("Sun Jul 29 13:24:02 +0000 2012"), tweetV1.getUser().getDateOfCreation());
   }
+
   @Test
   public void testEntities() {
     Entities entities = tweetV1.getEntities();
@@ -133,5 +135,40 @@ public class TweetDeserializerV1Test {
     assertEquals("http://www.facebook.com/rickroll548 As long as trolls are still trolling, the Rick will never stop rolling.", u.getDescription());
     assertEquals("RickRoll'D", u.getTitle());
 
+  }
+
+  @Test
+  public void testEntitiesMedia() {
+    List<? extends MediaEntity> media = tweetV1.getMedia();
+    assertNotNull(media);
+    assertEquals(1,media.size());
+
+    MediaEntity e = media.get(0);
+    assertNotNull(e);
+    assertEquals(219, e.getStart());
+    assertEquals(242, e.getEnd());
+    assertEquals(1293565706408038401L, e.getId());
+    assertEquals("https://pbs.twimg.com/ext_tw_video_thumb/1293565706408038401/pu/img/66P2dvbU4a02jYbV.jpg", e.getMediaUrl());
+    assertEquals("https://t.co/KaFSbjWUA8", e.getUrl());
+    assertEquals("pic.twitter.com/KaFSbjWUA8", e.getDisplayUrl());
+    assertEquals("https://twitter.com/TwitterDev/status/1293593516040269825/video/1", e.getExpandedUrl());
+    assertEquals("photo", e.getType());
+
+    TweetV1.MediaEntityV1 ev1 = (TweetV1.MediaEntityV1) e;
+    assertNotNull(ev1);
+    assertNotNull(ev1.getSizes());
+
+    checkMediaSizeContent(ev1.getSizes(), "thumb", 150, 150, "crop");
+    checkMediaSizeContent(ev1.getSizes(), "medium", 1200, 675, "fit");
+    checkMediaSizeContent(ev1.getSizes(), "small", 680, 383, "fit");
+    checkMediaSizeContent(ev1.getSizes(), "large", 1280, 720, "fit");
+  }
+
+  private void checkMediaSizeContent(Map<String, TweetV1.MediaSize> map, String key, int w, int h, String resize) {
+    TweetV1.MediaSize ms = map.get(key);
+    assertNotNull(ms);
+    assertEquals(h, ms.getHeight());
+    assertEquals(w, ms.getWidth());
+    assertEquals(resize, ms.getResize());
   }
 }

--- a/src/test/java/io/github/redouane59/twitter/unit/TweetDeserializerV2Test.java
+++ b/src/test/java/io/github/redouane59/twitter/unit/TweetDeserializerV2Test.java
@@ -8,8 +8,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.redouane59.twitter.TwitterClient;
 import io.github.redouane59.twitter.dto.tweet.ContextAnnotation;
+import io.github.redouane59.twitter.dto.tweet.TweetV1;
 import io.github.redouane59.twitter.dto.tweet.entities.HashtagEntity;
 import io.github.redouane59.twitter.dto.tweet.ReplySettings;
+import io.github.redouane59.twitter.dto.tweet.entities.MediaEntity;
 import io.github.redouane59.twitter.dto.tweet.entities.SymbolEntity;
 import io.github.redouane59.twitter.dto.tweet.Tweet;
 import io.github.redouane59.twitter.dto.tweet.TweetV2;
@@ -19,6 +21,7 @@ import io.github.redouane59.twitter.dto.user.User;
 import io.github.redouane59.twitter.helpers.ConverterHelper;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -148,13 +151,6 @@ public class TweetDeserializerV2Test {
   }
 
   @Test
-  public void testIncludesMedia() {
-    TweetV2 tweet = (TweetV2) tweetv2;
-    JsonNode media = tweet.getIncludes().getMedia();
-    assertNotNull(media);
-  }
-
-  @Test
   public void testEntities() {
     TweetV2 tweet = (TweetV2) tweetv2;
     TweetV2.EntitiesV2 entities = tweet.getData().getEntities();
@@ -208,6 +204,31 @@ public class TweetDeserializerV2Test {
     assertEquals(200, u.getStatus());
     assertEquals("From breaking news and entertainment to sports and politics, get the full story with all the live commentary.", u.getDescription());
     assertEquals("bird", u.getTitle());
+  }
 
+  @Test
+  public void testEntitiesMedia() {
+    List<? extends MediaEntity> media = tweetv2.getMedia();
+    assertNotNull(media);
+    assertEquals(1,media.size());
+
+    MediaEntity e = media.get(0);
+    assertNotNull(e);
+    assertEquals(-1, e.getStart());
+    assertEquals(-1, e.getEnd());
+    assertEquals(-1, e.getId());
+    assertEquals("https://pbs.twimg.com/ext_tw_video_thumb/1293565706408038401/pu/img/66P2dvbU4a02jYbV.jpg", e.getMediaUrl());
+    assertEquals("https://pbs.twimg.com/ext_tw_video_thumb/1293565706408038401/pu/img/66P2dvbU4a02jYbV.jpg", e.getUrl());
+    assertEquals("https://pbs.twimg.com/ext_tw_video_thumb/1293565706408038401/pu/img/66P2dvbU4a02jYbV.jpg", e.getDisplayUrl());
+    assertEquals("https://pbs.twimg.com/ext_tw_video_thumb/1293565706408038401/pu/img/66P2dvbU4a02jYbV.jpg", e.getExpandedUrl());
+    assertEquals("video", e.getType());
+
+    TweetV2.MediaEntityV2 ev2 = (TweetV2.MediaEntityV2) e;
+    assertNotNull(ev2);
+    assertEquals("3_1365362339449561088", ev2.getKey());
+    assertTrue(Arrays.asList(tweetv2.getAttachments().getMediaKeys()).contains(ev2.getKey()));
+    assertEquals(34875, ev2.getDuration());
+    assertEquals(720, ev2.getHeight());
+    assertEquals(1280, ev2.getWidth());
   }
 }

--- a/src/test/resources/tests/tweet_example_v1.json
+++ b/src/test/resources/tests/tweet_example_v1.json
@@ -111,6 +111,44 @@
               85
             ]
           }
+        ],
+        "media": [
+          {
+            "id": 1293565706408038401,
+            "id_str": "1293565706408038401",
+            "indices": [
+              219,
+              242
+            ],
+            "media_url": "http:\/\/pbs.twimg.com\/ext_tw_video_thumb\/1293565706408038401\/pu\/img\/66P2dvbU4a02jYbV.jpg",
+            "media_url_https": "https:\/\/pbs.twimg.com\/ext_tw_video_thumb\/1293565706408038401\/pu\/img\/66P2dvbU4a02jYbV.jpg",
+            "url": "https:\/\/t.co\/KaFSbjWUA8",
+            "display_url": "pic.twitter.com\/KaFSbjWUA8",
+            "expanded_url": "https:\/\/twitter.com\/TwitterDev\/status\/1293593516040269825\/video\/1",
+            "type": "photo",
+            "sizes": {
+              "thumb": {
+                "w": 150,
+                "h": 150,
+                "resize": "crop"
+              },
+              "medium": {
+                "w": 1200,
+                "h": 675,
+                "resize": "fit"
+              },
+              "small": {
+                "w": 680,
+                "h": 383,
+                "resize": "fit"
+              },
+              "large": {
+                "w": 1280,
+                "h": 720,
+                "resize": "fit"
+              }
+            }
+          }
         ]
       },
       "favorited":false,

--- a/src/test/resources/tests/tweet_example_v2.json
+++ b/src/test/resources/tests/tweet_example_v2.json
@@ -112,7 +112,7 @@
         "duration_ms": 34875,
         "media_key": "3_1365362339449561088",
         "type": "video",
-        "preview_image_url": "https://pbs.twimg.com/ext_tw_video_thumb/1293565706408038401/pu/img/66P2dvbU4a02jYbV.jpg",
+        "url": "https://pbs.twimg.com/ext_tw_video_thumb/1293565706408038401/pu/img/66P2dvbU4a02jYbV.jpg",
         "public_metrics": {
           "view_count": 279438
         },


### PR DESCRIPTION
# Introduction

I am currently in the process of testing this library to potentially replace `twitter4j` in our applications. For this reason, I am in the need to retrieve fully expanded media entitites for a given tweet.

# What does this PR do?

- Extends the current implementation to retrieve expanded `Media` objects via the V2 endpoints
- Extends the current implementation to retrieve `Media` objects via the V1 endpoints

# Additional thoughts?

- Any reason to have a full version identifier on the develop branch? Wouldn't it be nice to switch to a SNAPSHOT version instead? This would avoid some hassle, if the library is build and installed multiple times locally.
