### PR TITLE
Adds a FilteredStreamRulePredicate to build syntactically correct stream rules

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
+++ b/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
@@ -3,6 +3,7 @@ package io.github.redouane59.twitter;
 import com.github.scribejava.core.model.Response;
 import io.github.redouane59.twitter.dto.endpoints.AdditionalParameters;
 import io.github.redouane59.twitter.dto.others.BlockResponse;
+import io.github.redouane59.twitter.dto.rules.FilteredStreamRulePredicate;
 import io.github.redouane59.twitter.dto.stream.StreamRules.StreamMeta;
 import io.github.redouane59.twitter.dto.stream.StreamRules.StreamRule;
 import io.github.redouane59.twitter.dto.tweet.LikeResponse;
@@ -179,6 +180,23 @@ public interface ITwitterClientV2 {
    * @return the created rules
    */
   StreamRule addFilteredStreamRule(String value, String tag);
+
+  /**
+   * add a filtered stream rule calling https://api.twitter.com/2/tweets/search/stream/rules
+   *
+   * @param value the rule value
+   * @param tag the rule associated tag
+   * @return the created rules
+   */
+  StreamRule addFilteredStreamRule(FilteredStreamRulePredicate value, String tag);
+
+  /**
+   * Delete a filtered stream rule calling https://api.twitter.com/2/tweets/search/stream/rules
+   *
+   * @param ruleValue the value of the rule to delete
+   * @return a StreamMeta object resuming the operation
+   */
+  StreamMeta deleteFilteredStreamRule(FilteredStreamRulePredicate ruleValue);
 
   /**
    * Delete a filtered stream rule calling https://api.twitter.com/2/tweets/search/stream/rules

--- a/src/main/java/io/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/io/github/redouane59/twitter/TwitterClient.java
@@ -24,6 +24,7 @@ import io.github.redouane59.twitter.dto.getrelationship.RelationshipObjectRespon
 import io.github.redouane59.twitter.dto.others.BlockResponse;
 import io.github.redouane59.twitter.dto.others.RateLimitStatus;
 import io.github.redouane59.twitter.dto.others.RequestToken;
+import io.github.redouane59.twitter.dto.rules.FilteredStreamRulePredicate;
 import io.github.redouane59.twitter.dto.stream.StreamRules;
 import io.github.redouane59.twitter.dto.stream.StreamRules.StreamMeta;
 import io.github.redouane59.twitter.dto.stream.StreamRules.StreamRule;
@@ -825,6 +826,16 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
       LOGGER.error(e.getMessage(), e);
       throw new IllegalArgumentException();
     }
+  }
+
+  @Override
+  public StreamRule addFilteredStreamRule(FilteredStreamRulePredicate value, String tag) {
+    return this.addFilteredStreamRule(value.toString(), tag);
+  }
+
+  @Override
+  public StreamMeta deleteFilteredStreamRule(FilteredStreamRulePredicate ruleValue) {
+    return this.deleteFilteredStreamRule(ruleValue.toString());
   }
 
   @Override

--- a/src/main/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicate.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicate.java
@@ -1,0 +1,221 @@
+package io.github.redouane59.twitter.dto.rules;
+
+/**
+ * This class brings support for enhanced filter rules for the filtered streaming API V2
+ *
+ * {@see <a href="https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/build-a-rule}">https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/build-a-rule}</a>
+ */
+public class FilteredStreamRulePredicate {
+
+    private String predicate;
+
+    FilteredStreamRulePredicate() {}
+
+    private static FilteredStreamRulePredicate build(String one, String two, String operator) {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        if (one.isEmpty()) {
+            p.predicate = operator + two;
+        } else {
+            p.predicate = one + " " + operator + two;
+        }
+        return p;
+    }
+
+    public static FilteredStreamRulePredicate withKeyword(String keyword) {
+        return build("", keyword, "");
+    }
+
+    public static FilteredStreamRulePredicate withEmoji(String emoji) {
+        return build("", emoji, "");
+    }
+
+    public static FilteredStreamRulePredicate withExactPhrase(String phrase) {
+        return build("", "\"" + phrase + "\"", "");
+    }
+
+    public static FilteredStreamRulePredicate withHashtag(String hashtag) {
+        return build("", hashtag.startsWith("#") ? hashtag : "#" + hashtag, "");
+    }
+
+    public static FilteredStreamRulePredicate withMention(String mention) {
+        return build("", mention.startsWith("@") ? mention : "@" + mention, "");
+    }
+
+    public static FilteredStreamRulePredicate withCashtag(String cashtag) {
+        return build("", cashtag.startsWith("$") ? cashtag : "$" + cashtag, "");
+    }
+
+    public static FilteredStreamRulePredicate withUser(String user) {
+        return build("", user, "from:");
+    }
+
+    public static FilteredStreamRulePredicate withReplyTo(String user) {
+        return build("", user, "to:");
+    }
+
+    public static FilteredStreamRulePredicate witUrl(String url) {
+        return build("", withExactPhrase(url).toString(), "url:");
+    }
+
+    public static FilteredStreamRulePredicate withRetweetsOf(String user) {
+        return build("", user, "retweets_of:");
+    }
+
+    public static FilteredStreamRulePredicate withContext(String context) {
+        return build("", context, "context:");
+    }
+
+    public static FilteredStreamRulePredicate withEntity(String entity) {
+        return build("", withExactPhrase(entity).toString(), "entity:");
+    }
+
+    public static FilteredStreamRulePredicate withConversationId(String conversationId) {
+        return build("", conversationId, "conversation_id:");
+    }
+
+    public static FilteredStreamRulePredicate withBio(String bio) {
+        return build("", bio, "bio:");
+    }
+
+    public static FilteredStreamRulePredicate withBioName(String bioName) {
+        return build("", bioName, "bio_name:");
+    }
+
+    public static FilteredStreamRulePredicate withBioLocation(String bioLocation) {
+        return build("", bioLocation, "bio_location:");
+    }
+
+    public static FilteredStreamRulePredicate withPlace(String place) {
+        return build("", place, "place:");
+    }
+
+    public static FilteredStreamRulePredicate withPlaceCountry(String alpha2IsoCode) {
+        return build("", alpha2IsoCode, "place_country:");
+    }
+
+    public static FilteredStreamRulePredicate withPointRadius(double longitude, double latitude, String radius) {
+        //mi or km
+        return build("", "[" + longitude + " " + latitude + " " + radius + "]", "point_radius:");
+    }
+
+    public static FilteredStreamRulePredicate withBoundingBox(double westLongitude, double southLatitude, double eastLongitude, double northLatitude) {
+        //mi or km
+        return build("", "[" + westLongitude + " " + southLatitude + " " + eastLongitude + " " + northLatitude + "]", "bounding_box:");
+    }
+
+    public static FilteredStreamRulePredicate withLanguage(String language) {
+        return build("", language, "lang:");
+    }
+
+    public static FilteredStreamRulePredicate isRetweet(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "is:retweet");
+    }
+
+    public static FilteredStreamRulePredicate isReply(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "is:reply");
+    }
+
+    public static FilteredStreamRulePredicate isQuote(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "is:quote");
+    }
+
+    public static FilteredStreamRulePredicate isVerified(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "is:verified");
+    }
+
+    public static FilteredStreamRulePredicate isNullcast(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "-is:nullcast");
+    }
+
+    public static FilteredStreamRulePredicate hasHashtags(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "has:hashtags");
+    }
+
+    public static FilteredStreamRulePredicate hasCashtags(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "has:cashtags");
+    }
+
+    public static FilteredStreamRulePredicate hasLinks(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "has:links");
+    }
+
+    public static FilteredStreamRulePredicate hasMentions(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "has:mentions");
+    }
+
+    public static FilteredStreamRulePredicate hasMedia(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "has:media");
+    }
+
+    public static FilteredStreamRulePredicate hasImages(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "has:images");
+    }
+
+    public static FilteredStreamRulePredicate hasVideos(FilteredStreamRulePredicate predicate) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), "", "has:videos");
+    }
+
+    public static FilteredStreamRulePredicate hasGeo(FilteredStreamRulePredicate predicate, String geo) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), " " + geo, "has:geo");
+    }
+
+    public static FilteredStreamRulePredicate doSampling(FilteredStreamRulePredicate predicate, int sampleSize) {
+        checkConjunction(predicate);
+        return build(predicate.toString(), Integer.toString(sampleSize), "sample:");
+    }
+
+    public FilteredStreamRulePredicate negate() {
+        predicate = "-" + capsule();
+        return this;
+    }
+
+    public FilteredStreamRulePredicate capsule() {
+        predicate = "(" + predicate + ")";
+        return this;
+    }
+
+    public FilteredStreamRulePredicate or(FilteredStreamRulePredicate other) {
+        predicate += " OR " + other.predicate;
+        return this;
+    }
+
+    public FilteredStreamRulePredicate and(FilteredStreamRulePredicate other) {
+        predicate += " AND " + other.predicate;
+        return this;
+    }
+
+    public boolean isEmpty() {
+        return predicate == null || predicate.isEmpty();
+    }
+
+    private static void checkConjunction(FilteredStreamRulePredicate predicate) {
+        if (predicate == null || predicate.isEmpty()) {
+            throw new RuleBuilderException("Given operator can only be used in an conjunction");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return predicate;
+    }
+
+    public static class RuleBuilderException extends RuntimeException {
+        public RuleBuilderException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/src/test/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicateTest.java
+++ b/src/test/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicateTest.java
@@ -1,0 +1,397 @@
+package io.github.redouane59.twitter.dto.rules;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FilteredStreamRulePredicateTest {
+
+    @Test
+    void testExactPhrase() {
+        assertEquals("\"test\"", FilteredStreamRulePredicate.withExactPhrase("test").toString());
+    }
+
+    @Test
+    void testKeyword() {
+        assertEquals("test", FilteredStreamRulePredicate.withKeyword("test").toString());
+    }
+
+    @Test
+    void testEmoji() {
+        assertEquals("\uD83D\uDE1C", FilteredStreamRulePredicate.withEmoji("\uD83D\uDE1C").toString());
+    }
+
+    @Test
+    void testWithHashtag1() {
+        assertEquals("#test", FilteredStreamRulePredicate.withHashtag("test").toString());
+    }
+
+    @Test
+    void testWithHashtag2() {
+        assertEquals("#test", FilteredStreamRulePredicate.withHashtag("#test").toString());
+    }
+
+    @Test
+    void testWithMention1() {
+        assertEquals("@test", FilteredStreamRulePredicate.withMention("test").toString());
+    }
+
+    @Test
+    void testWithMention2() {
+        assertEquals("@test", FilteredStreamRulePredicate.withMention("@test").toString());
+    }
+
+    @Test
+    void testWithCashtag1() {
+        assertEquals("$test", FilteredStreamRulePredicate.withCashtag("test").toString());
+    }
+
+    @Test
+    void testWithCashtag2() {
+        assertEquals("$test", FilteredStreamRulePredicate.withCashtag("$test").toString());
+    }
+
+    @Test
+    void testWithUser1() {
+        assertEquals("from:test", FilteredStreamRulePredicate.withUser("test").toString());
+    }
+
+    @Test
+    void testWithUser2() {
+        assertEquals("from:1541513", FilteredStreamRulePredicate.withUser("1541513").toString());
+    }
+
+    @Test
+    void testWithReplyTo1() {
+        assertEquals("to:test", FilteredStreamRulePredicate.withReplyTo("test").toString());
+    }
+
+    @Test
+    void testWithReplyTo2() {
+        assertEquals("to:1541513", FilteredStreamRulePredicate.withReplyTo("1541513").toString());
+    }
+
+    @Test
+    void testWithUrl() {
+        assertEquals("url:\"https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/build-a-rule\"", FilteredStreamRulePredicate.witUrl("https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/build-a-rule").toString());
+    }
+
+    @Test
+    void testWithRetweetsOf1() {
+        assertEquals("retweets_of:test", FilteredStreamRulePredicate.withRetweetsOf("test").toString());
+    }
+
+    @Test
+    void testWithRetweetsOf2() {
+        assertEquals("retweets_of:1541513", FilteredStreamRulePredicate.withRetweetsOf("1541513").toString());
+    }
+
+    @Test
+    void testWithContext() {
+        assertEquals("context:*.799022225751871488", FilteredStreamRulePredicate.withContext("*.799022225751871488").toString());
+    }
+
+    @Test
+    void testWithEntity() {
+        assertEquals("entity:\"Michael Jordan\"", FilteredStreamRulePredicate.withEntity("Michael Jordan").toString());
+    }
+
+    @Test
+    void testWithConversationId() {
+        assertEquals("conversation_id:1334987486343299072", FilteredStreamRulePredicate.withConversationId("1334987486343299072").toString());
+    }
+
+    @Test
+    void testWithBio() {
+        assertEquals("bio:test", FilteredStreamRulePredicate.withBio("test").toString());
+    }
+
+    @Test
+    void testWithBioName() {
+        assertEquals("bio_name:test", FilteredStreamRulePredicate.withBioName("test").toString());
+    }
+
+    @Test
+    void testWithBioLocation() {
+        assertEquals("bio_location:nyc", FilteredStreamRulePredicate.withBioLocation("nyc").toString());
+    }
+
+    @Test
+    void testWithPlace() {
+        assertEquals("place:seattle", FilteredStreamRulePredicate.withPlace("seattle").toString());
+    }
+
+    @Test
+    void testWithPlaceCountry() {
+        assertEquals("place_country:DE", FilteredStreamRulePredicate.withPlaceCountry("DE").toString());
+    }
+
+    @Test
+    void testWithPointRadius() {
+        assertEquals("point_radius:[2.355128 48.861118 16km]", FilteredStreamRulePredicate.withPointRadius(2.355128, 48.861118, "16km").toString());
+    }
+
+    @Test
+    void testWithBoundingBox() {
+        assertEquals("bounding_box:[-105.301758 39.964069 -105.178505 40.09455]", FilteredStreamRulePredicate.withBoundingBox(-105.301758, 39.964069, -105.178505, 40.09455).toString());
+    }
+
+    @Test
+    void testWithLanguage() {
+        assertEquals("lang:de", FilteredStreamRulePredicate.withLanguage("de").toString());
+    }
+
+    @Test
+    void testNegateRule() {
+        assertEquals("-(point_radius:[2.355128 48.861118 16km])", FilteredStreamRulePredicate.withPointRadius(2.355128, 48.861118, "16km").negate().toString());
+    }
+
+    @Test
+    void testCapsule() {
+        assertEquals("(point_radius:[2.355128 48.861118 16km])", FilteredStreamRulePredicate.withPointRadius(2.355128, 48.861118, "16km").capsule().toString());
+    }
+
+    @Test
+    void testIsRetweet() {
+        assertEquals("test is:retweet", FilteredStreamRulePredicate.isRetweet(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testIsReply() {
+        assertEquals("test is:reply", FilteredStreamRulePredicate.isReply(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testIsQuote() {
+        assertEquals("test is:quote", FilteredStreamRulePredicate.isQuote(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testIsVerified() {
+        assertEquals("test is:verified", FilteredStreamRulePredicate.isVerified(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testIsNullcast() {
+        assertEquals("test -is:nullcast", FilteredStreamRulePredicate.isNullcast(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testHasHashtags() {
+        assertEquals("test has:hashtags", FilteredStreamRulePredicate.hasHashtags(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testHasCashtags() {
+        assertEquals("test has:cashtags", FilteredStreamRulePredicate.hasCashtags(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testHasLinks() {
+        assertEquals("test has:links", FilteredStreamRulePredicate.hasLinks(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testHasMentions() {
+        assertEquals("test has:mentions", FilteredStreamRulePredicate.hasMentions(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testHasMedia() {
+        assertEquals("test has:media", FilteredStreamRulePredicate.hasMedia(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testHasImages() {
+        assertEquals("test has:images", FilteredStreamRulePredicate.hasImages(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testHasVideos() {
+        assertEquals("test has:videos", FilteredStreamRulePredicate.hasVideos(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    }
+
+    @Test
+    void testHasGeo() {
+        assertEquals("test has:geo bakery", FilteredStreamRulePredicate.hasGeo(FilteredStreamRulePredicate.withKeyword("test"), "bakery").toString());
+    }
+
+    @Test
+    void testSample() {
+        assertEquals("test sample:15", FilteredStreamRulePredicate.doSampling(FilteredStreamRulePredicate.withKeyword("test"), 15).toString());
+    }
+
+    @Test
+    void testComplexQueries1() {
+        FilteredStreamRulePredicate p = FilteredStreamRulePredicate.withExactPhrase("test");
+        FilteredStreamRulePredicate p2 = FilteredStreamRulePredicate.withBioName("test");
+        FilteredStreamRulePredicate p3 = FilteredStreamRulePredicate.withLanguage("de");
+        FilteredStreamRulePredicate p4 = FilteredStreamRulePredicate.withLanguage("en").negate();
+        assertEquals("((\"test\" AND bio_name:test) OR lang:de) OR -(lang:en)", p.and(p2).capsule().or(p3).capsule().or(p4).toString());
+    }
+
+    @Test
+    void testComplexQueries2() {
+        FilteredStreamRulePredicate p = FilteredStreamRulePredicate.withExactPhrase("test");
+        FilteredStreamRulePredicate p2 = FilteredStreamRulePredicate.withBioName("test");
+        FilteredStreamRulePredicate p3 = FilteredStreamRulePredicate.withLanguage("de");
+        FilteredStreamRulePredicate p4 = FilteredStreamRulePredicate.withLanguage("en").negate();
+        assertEquals("((\"test\" AND bio_name:test) OR lang:de) OR -(lang:en) sample:15", FilteredStreamRulePredicate.doSampling(p.and(p2).capsule().or(p3).capsule().or(p4), 15).toString());
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid1() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isReply(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isReply(p);
+        });
+
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid2() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isRetweet(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isRetweet(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid3() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isQuote(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isQuote(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid4() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isVerified(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isVerified(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid5() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isNullcast(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.isNullcast(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid6() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasHashtags(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasHashtags(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid7() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasCashtags(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasCashtags(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid8() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasLinks(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasLinks(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid9() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasMentions(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasMentions(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid10() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasMedia(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasMedia(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid11() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasImages(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasImages(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid12() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasVideos(null);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasVideos(p);
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid13() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasGeo(null, "test");
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.hasGeo(p, "test");
+        });
+    }
+
+    @Test
+    void testConjunctionOperatorsInvalid14() {
+        FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.doSampling(null, 15);
+        });
+        Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
+            FilteredStreamRulePredicate.doSampling(p, 15);
+        });
+    }
+}


### PR DESCRIPTION
# What does this PR do?

We want to add complex queries to the Filtered Stream Rules API within our application. 

Before doing this in our software itself, I thought it would be neat to have a building mechanism inside the actual Twitter library.

Might need some more love regarding documentation and additional checks, but it can be considered as a **draft** open for discussion.