### PR TITLE
Replace deleteFilteredStreamRuletag by deleteFilteredStreamRuleId

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
+++ b/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
@@ -210,7 +210,7 @@ public interface ITwitterClientV2 {
   StreamMeta deleteFilteredStreamRule(String ruleValue);
 
   /**
-   * Delete a filtered stream from its rule tag calling https://api.twitter.com/2/tweets/search/stream/rules
+   * Delete a filtered stream from its rule id calling https://api.twitter.com/2/tweets/search/stream/rules
    *
    * @param ruleId the id returned when using retrieveFilteredStreamRules
    * @return a StreamMeta object resuming the operation

--- a/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
+++ b/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
@@ -212,10 +212,10 @@ public interface ITwitterClientV2 {
   /**
    * Delete a filtered stream from its rule tag calling https://api.twitter.com/2/tweets/search/stream/rules
    *
-   * @param ruleTag the tag name specified when using addFilteredStreamRule
+   * @param ruleId the id returned when using retrieveFilteredStreamRules
    * @return a StreamMeta object resuming the operation
    */
-  StreamMeta deleteFilteredStreamRuletag(String ruleTag);
+  StreamMeta deleteFilteredStreamRuleId(String ruleId);
 
   /**
    * Retrieve the filtered stream rules calling https://api.twitter.com/2/tweets/search/stream/rules

--- a/src/main/java/io/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/io/github/redouane59/twitter/TwitterClient.java
@@ -904,9 +904,9 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   }
 
   @Override
-  public StreamMeta deleteFilteredStreamRuletag(String ruleTag) {
+  public StreamMeta deleteFilteredStreamRuleId(String ruleId) {
     String      url    = urlHelper.getFilteredStreamRulesUrl();
-    String      body   = "{\"delete\": {\"ids\": [\"" + ruleTag + "\"]}}";
+    String      body   = "{\"delete\": {\"ids\": [\"" + ruleId + "\"]}}";
     StreamRules result = requestHelperV2.postRequest(url, body, StreamRules.class).orElseThrow(NoSuchElementException::new);
     return result.getMeta();
   }


### PR DESCRIPTION
Twitter API has not an endpoint to delete a stream rule by tag. Instead of that, it has one to delete it by id.
@link https://documenter.getpostman.com/view/9956214/T1LMiT5U#6960d456-14d6-4042-a3cd-5ae2add9e499