### PR TITLE
Fix outOfBound Exception if the count is bigger than the result size

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/io/github/redouane59/twitter/TwitterClient.java
@@ -1120,10 +1120,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
       url = getUrlHelper().getDMListUrl(maxCount) + "&" + CURSOR + "=" + dmListAnswer.getNextCursor();
     }
     while (dmListAnswer.getNextCursor() != null && result.size() < count);
-    if (count == Integer.MAX_VALUE) {
-      return result;
-    }
-    return result.subList(0, count); // to fix the API bug which is not giving the right count
+    return result.subList(0, Math.min(count,result.size())); // to fix the API bug which is not giving the right count
   }
 
   @Override


### PR DESCRIPTION
With a small count of lesser than 50  Direct Message if we call getDmList(50) we have an OutOfBound Exception

To test it use unit test : testGetDmListWithCountAndGetDm() on a twitter account with less than 55 Direct message
