### PR TITLE
Fixed bug where there was no profile image available for the v1 user

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/dto/user/UserV1.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/user/UserV1.java
@@ -51,6 +51,8 @@ public class UserV1 implements User {
   private String      dateOfCreation;
   private String      lastUpdate;
   private String      location;
+  @JsonProperty("profile_image_url")
+  private String      profileImageUrl;
   private boolean     following;
 
   @Override
@@ -74,12 +76,6 @@ public class UserV1 implements User {
 
   @Override
   public Tweet getPinnedTweet() {
-    LOGGER.debug("UnsupportedOperation");
-    return null;
-  }
-
-  @Override
-  public String getProfileImageUrl() {
     LOGGER.debug("UnsupportedOperation");
     return null;
   }


### PR DESCRIPTION
Hi, I noticed that the library does not retrieve the profile image for V1 Users but it can (responses always contain the profile_pic_url). Would be great to have it in the responses - thanks!