### PR TITLE
fix: do not sign the request for POST oauth/access_token

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/io/github/redouane59/twitter/TwitterClient.java
@@ -1128,7 +1128,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     Map<String, String> parameters = new HashMap<>();
     parameters.put("oauth_verifier", pinCode);
     parameters.put("oauth_token", requestToken.getOauthToken());
-    String stringResponse = requestHelperV1.postRequest(url, parameters, String.class).orElseThrow(NoSuchElementException::new);
+    String stringResponse = requestHelperV1.postRequestWithoutSign(url, parameters, String.class).orElseThrow(NoSuchElementException::new);
     return new RequestToken(stringResponse);
   }
 

--- a/src/main/java/io/github/redouane59/twitter/helpers/RequestHelper.java
+++ b/src/main/java/io/github/redouane59/twitter/helpers/RequestHelper.java
@@ -31,6 +31,10 @@ public class RequestHelper extends AbstractRequestHelper {
     return postRequestWithBodyJson(url, parameters, null, classType);
   }
 
+  public <T> Optional<T> postRequestWithoutSign(String url, Map<String, String> parameters, Class<T> classType) {
+    return makeRequest(Verb.POST, url, parameters, null, false, classType);
+  }
+
   public <T> Optional<T> uploadMedia(String url, File file, Class<T> classType) {
     try {
       return uploadMedia(url, file.getName(), Files.readAllBytes(file.toPath()), classType);


### PR DESCRIPTION
Fix Issue #310.

The `POST /oauth/access_token` endpoint does not require the `Authorization` header to be set [1]. If `signRequired` is `true` in
`makeRequest()`, then OAuth 1.0 parameters will be added to the `Authorization` header [2,3].  Twitter will then return `401 -
Request Token missing` as a response for the `POST` request.

This might be a bug of Twitter API as Twitter should ignore the `Authorization` header in this endpoint when it is not required.

\[1\]: https://developer.twitter.com/en/docs/authentication/api-reference/access_token
[2]: https://github.com/scribejava/scribejava/blob/124745961e999ccede90e2348c6012f8d335eb8a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java#L165
[3]: https://github.com/scribejava/scribejava/blob/124745961e999ccede90e2348c6012f8d335eb8a/scribejava-core/src/main/java/com/github/scribejava/core/oauth/OAuth10aService.java#L86