### PR TITLE
add non-public tweet metrics and misc fields for API v2

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
+++ b/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
@@ -27,6 +27,15 @@ import java.util.function.Consumer;
 
 public interface ITwitterClientV2 {
 
+  public static enum REQUEST_TWEET_FIELDS_SCOPE {
+      /** Retrieve public fields of tweets only (any token)*/
+      PUBLIC, 
+      /** Retrieve also non-public fields of tweets (needs user token) */
+      NON_PUBLIC, 
+      /** Retrieve non-public and promoted fields of tweets (needs user token, tweet must be promoted or request fails) */
+      NON_PUBLIC_PROMOTED 
+  }
+
   /**
    * Retreive a user from his screen name calling https://api.twitter.com/2/users/
    *
@@ -96,19 +105,39 @@ public interface ITwitterClientV2 {
 
   /**
    * Get a tweet from its id calling https://api.twitter.com/2/tweets
+   * with public fields only
    *
    * @param tweetId id of the tweet
    * @return a tweet object
    */
   Tweet getTweet(String tweetId);
+  
+  /**
+   * Get a tweet from its id calling https://api.twitter.com/2/tweets
+   * with given fields scope
+   *
+   * @param tweetId id of the tweet
+   * @return a tweet object
+   */
+  Tweet getTweet(String tweetId, REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope);
 
   /**
    * Get a tweet list from their id calling https://api.twitter.com/2/tweets
+   * with public fields only
    *
    * @param tweetIds the ids of the tweets
    * @return a tweet object list
    */
   TweetList getTweets(List<String> tweetIds);
+
+  /**
+   * Get a tweet list from their id calling https://api.twitter.com/2/tweets
+   * with given fields scope
+   *
+   * @param tweetIds the ids of the tweets
+   * @return a tweet object list
+   */
+  TweetList getTweets(List<String> tweetIds, REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope);
 
   /**
    * Hide/Unide a reply using https://api.twitter.com/labs/2/tweets/:id/hidden
@@ -288,6 +317,25 @@ public interface ITwitterClientV2 {
    * @return a TweetList object containing a list of tweets and the next token if recursiveCall is set to false
    */
   TweetList getUserTimeline(String userId, AdditionalParameters additionalParameters);
+
+  /**
+   * Get the most recent Tweets posted by the user calling https://api.twitter.com/2/users/:id/tweets (time & tweet id arguments can be null)
+   *
+   * @param userId identifier of the Twitter account (user ID) for whom to return results.
+   * @param requestTweetFieldsScope 
+   * @return a TweetList object containing a list of tweets and the next token if recursiveCall is set to false
+   */
+  public TweetList getUserTimeline(final String userId, REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope);
+  
+  /**
+   * Get the most recent Tweets posted by the user calling https://api.twitter.com/2/users/:id/tweets (time & tweet id arguments can be null)
+   *
+   * @param userId identifier of the Twitter account (user ID) for whom to return results.
+   * @param additionalParameters accepted parameters recursiveCall, startTime, endTime, sinceId, untilId, maxResults
+   * @param requestTweetFieldsScope
+   * @return a TweetList object containing a list of tweets and the next token if recursiveCall is set to false
+   */
+  public TweetList getUserTimeline(String userId, AdditionalParameters additionalParameters, REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope);
 
   /**
    * Get the most recent mentions received posted by the user calling https://api.twitter.com/2/users/:id/mentions

--- a/src/main/java/io/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/io/github/redouane59/twitter/TwitterClient.java
@@ -102,9 +102,12 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
       .setSerializationInclusion(JsonInclude.Include.NON_NULL)
       .findAndRegisterModules();
   public static final String       TWEET_FIELDS     = "tweet.fields";
-  public static final String
-                                   ALL_TWEET_FIELDS =
-      "attachments,author_id,created_at,entities,geo,id,in_reply_to_user_id,lang,possibly_sensitive,public_metrics,referenced_tweets,source,text,withheld,context_annotations,conversation_id,reply_settings";
+  public static final String       ALL_TWEET_FIELDS_PUBLIC = 
+      "attachments,author_id,created_at,entities,geo,id,in_reply_to_user_id,lang,possibly_sensitive,referenced_tweets,source,text,withheld,context_annotations,conversation_id,reply_settings,public_metrics";
+  public static final String       ALL_TWEET_FIELDS_NON_PUBLIC = 
+      ALL_TWEET_FIELDS_PUBLIC + ",non_public_metrics,organic_metrics";
+  public static final String       ALL_TWEET_FIELDS_NON_PUBLIC_PROMOTED = 
+      ALL_TWEET_FIELDS_NON_PUBLIC + ",promoted_metrics";
   public static final String       EXPANSION        = "expansions";
   public static final String
                                    ALL_EXPANSIONS   =
@@ -154,7 +157,12 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   public TwitterClient(TwitterCredentials credentials) {
     this(credentials, new ServiceBuilder(credentials.getApiKey()).apiSecret(credentials.getApiSecretKey()));
   }
-
+  
+  public TwitterClient(TwitterCredentials credentials, boolean useConsumerKey) {
+    this(credentials, new ServiceBuilder(credentials.getApiKey()).apiSecret(credentials.getApiSecretKey()));
+    setUseConsumerKey(useConsumerKey);
+  }
+  
   public TwitterClient(TwitterCredentials credentials, HttpClient httpClient) {
     this(credentials,
          new ServiceBuilder(credentials.getApiKey()).apiSecret(credentials.getApiSecretKey()).httpClient(httpClient));
@@ -233,6 +241,15 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   public void setAutomaticRetry(boolean automaticRetry) {
     requestHelperV1.setAutomaticRetry(automaticRetry);
     requestHelperV2.setAutomaticRetry(automaticRetry);
+  }
+
+  /**
+   * Set the behavior of authentication context used in requests. 
+   *
+   * @param useConsumerKey Using consumer key for user context if true; or else app-only bearer token. Default is false.
+   */
+  public void setUseConsumerKey(boolean useConsumerKey) {
+    requestHelperV2.setUseConsumerKey(useConsumerKey);
   }
 
   // can manage up to 5000 results / call . Max 15 calls / 15min ==> 75.000
@@ -515,7 +532,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   public TweetList getLikedTweets(final String userId, AdditionalParameters additionalParameters) {
     String              url        = getUrlHelper().getLikedTweetsUrl(userId);
     Map<String, String> parameters = new HashMap<>();
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     if (!additionalParameters.isRecursiveCall()) {
       return getRequestHelper().getRequestWithParameters(url, parameters, TweetList.class).orElseThrow(NoSuchElementException::new);
     }
@@ -576,7 +593,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(EXPANSION, PINNED_TWEET_ID);
     parameters.put(MAX_RESULTS, "1000");
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     return requestHelperV1.getRequestWithParameters(url, parameters, UserList.class).orElseThrow(NoSuchElementException::new);
   }
 
@@ -646,7 +663,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     Map<String, String> parameters = new HashMap<>();
     parameters.put(EXPANSION, PINNED_TWEET_ID);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     return getRequestHelperV2().getRequestWithParameters(url, parameters, UserList.class)
                                .orElseThrow(NoSuchElementException::new);
   }
@@ -751,7 +768,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     Map<String, String> parameters = new HashMap<>();
     parameters.put(EXPANSION, PINNED_TWEET_ID);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     return getUsersRecursively(Integer.MAX_VALUE, url, parameters);
   }
 
@@ -788,10 +805,15 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
 
   @Override
   public Tweet getTweet(String tweetId) {
+    return getTweet(tweetId, REQUEST_TWEET_FIELDS_SCOPE.PUBLIC);
+  }
+
+  @Override
+  public Tweet getTweet(String tweetId, REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope) {
     String              url        = getUrlHelper().getTweetUrl(tweetId);
     Map<String, String> parameters = new HashMap<>();
     parameters.put(EXPANSION, ALL_EXPANSIONS);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, getFieldsForRequestTweetFieldsScope(requestTweetFieldsScope));
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     return getRequestHelper().getRequestWithParameters(url, parameters, TweetV2.class).orElseThrow(NoSuchElementException::new);
@@ -799,10 +821,15 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
 
   @Override
   public TweetList getTweets(List<String> tweetIds) {
+      return getTweets(tweetIds, REQUEST_TWEET_FIELDS_SCOPE.PUBLIC);
+  }
+
+  @Override
+  public TweetList getTweets(List<String> tweetIds, REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope) {
     String              url        = getUrlHelper().getTweetsUrl();
     Map<String, String> parameters = new HashMap<>();
     parameters.put(EXPANSION, ALL_EXPANSIONS);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, getFieldsForRequestTweetFieldsScope(requestTweetFieldsScope));
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     StringBuilder result = new StringBuilder();
@@ -841,7 +868,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   public TweetList searchTweets(String query, AdditionalParameters additionalParameters) {
     Map<String, String> parameters = additionalParameters.getMapFromParameters();
     parameters.put(QUERY, query);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(EXPANSION, ALL_EXPANSIONS);
     parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
@@ -865,10 +892,10 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     Map<String, String> parameters = additionalParameters.getMapFromParameters();
     parameters.put(QUERY, query);
     if (additionalParameters.getMaxResults() <= 100) {
-      parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+      parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     } else {
       LOGGER.warn("removing context_annotations from tweet_fields because max_result is greater 100");
-      parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS.replace(",context_annotations", ""));
+      parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC.replace(",context_annotations", ""));
     }
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(EXPANSION, ALL_EXPANSIONS);
@@ -1004,7 +1031,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     String              url        = urlHelper.getFilteredStreamUrl();
     Map<String, String> parameters = new HashMap<>();
     parameters.put(EXPANSION, ALL_EXPANSIONS);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     return requestHelperV2.getAsyncRequest(url, parameters, consumer);
@@ -1020,7 +1047,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     String              url        = urlHelper.getFilteredStreamUrl();
     Map<String, String> parameters = new HashMap<>();
     parameters.put(EXPANSION, ALL_EXPANSIONS);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     if (backfillMinutes > 0) {
@@ -1100,7 +1127,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     String              url        = urlHelper.getSampledStreamUrl();
     Map<String, String> parameters = new HashMap<>();
     parameters.put(EXPANSION, ALL_EXPANSIONS);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     return requestHelperV2.getAsyncRequest(url, parameters, consumer);
@@ -1116,7 +1143,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     String              url        = urlHelper.getSampledStreamUrl();
     Map<String, String> parameters = new HashMap<>();
     parameters.put(EXPANSION, ALL_EXPANSIONS);
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     if (backfillMinutes > 0) {
@@ -1127,13 +1154,23 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
 
   @Override
   public TweetList getUserTimeline(final String userId) {
-    return getUserTimeline(userId, AdditionalParameters.builder().maxResults(100).build());
+    return getUserTimeline(userId, AdditionalParameters.builder().maxResults(100).build(), REQUEST_TWEET_FIELDS_SCOPE.PUBLIC);
   }
 
   @Override
-  public TweetList getUserTimeline(String userId, AdditionalParameters additionalParameters) {
+  public TweetList getUserTimeline(final String userId, AdditionalParameters additionalParameters) {
+    return getUserTimeline(userId, additionalParameters, REQUEST_TWEET_FIELDS_SCOPE.PUBLIC);
+  }
+
+  @Override
+  public TweetList getUserTimeline(final String userId, REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope) {
+    return getUserTimeline(userId, AdditionalParameters.builder().maxResults(100).build(), requestTweetFieldsScope);
+  }
+
+  @Override
+  public TweetList getUserTimeline(String userId, AdditionalParameters additionalParameters, REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope) {
     Map<String, String> parameters = additionalParameters.getMapFromParameters();
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, getFieldsForRequestTweetFieldsScope(requestTweetFieldsScope));
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(PLACE_FIELDS, ALL_PLACE_FIELDS);
     parameters.put(POLL_FIELDS, ALL_POLL_FIELDS);
@@ -1157,7 +1194,7 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   @Override
   public TweetList getUserMentions(final String userId, AdditionalParameters additionalParameters) {
     Map<String, String> parameters = additionalParameters.getMapFromParameters();
-    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS_PUBLIC);
     String url = urlHelper.getUserMentionsUrl(userId);
     if (!additionalParameters.isRecursiveCall()) {
       return getRequestHelperV2().getRequestWithParameters(url, parameters, TweetList.class).orElseThrow(NoSuchElementException::new);
@@ -1378,4 +1415,18 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     }
     return accessToken.substring(0, accessToken.indexOf("-"));
   }
+
+  public String getFieldsForRequestTweetFieldsScope(REQUEST_TWEET_FIELDS_SCOPE requestTweetFieldsScope) {
+    switch (requestTweetFieldsScope) {
+      case NON_PUBLIC:
+        return ALL_TWEET_FIELDS_NON_PUBLIC;
+      case NON_PUBLIC_PROMOTED:
+        return ALL_TWEET_FIELDS_NON_PUBLIC_PROMOTED;
+      case PUBLIC:
+        return ALL_TWEET_FIELDS_PUBLIC;
+      default:
+        throw new RuntimeException("REQUEST_TWEET_FIELDS_SCOPE " + requestTweetFieldsScope + " not implemented.");
+    }
+  }
+
 }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/Attachments.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/Attachments.java
@@ -16,5 +16,7 @@ public class Attachments {
 
   @JsonProperty("media_keys")
   private String[] mediaKeys;
+  @JsonProperty("poll_ids")
+  private String[] pollIds;
 
 }

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/Tweet.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/Tweet.java
@@ -67,6 +67,165 @@ public interface Tweet {
   int getQuoteCount();
 
   /**
+   * Get the number of times the Tweet has been viewed. This is a private metric, and requires the
+   * use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   *
+   * @return the number of times the Tweet has been viewed.
+   */
+  int getImpressionCount();
+
+  /**
+   * Get the number of times a user clicks on a URL link or URL preview card in a Tweet. This is a
+   * private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   *
+   * @return the number of times a user clicks on a URL link or URL preview card in a Tweet.
+   */
+  int getUrlLinkClicks();
+
+  /**
+   * Get the number of times a user clicks the following portions of a Tweet - display name, user
+   * name, profile picture. This is a private metric, and requires the use of OAuth 1.0a or OAuth
+   * 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   *
+   * @return the number of times a user clicks the following portions of a Tweet - display name,
+   *         user name, profile picture.
+   */
+  int getUserProfileClicks();
+
+  /**
+   * Get the number of times the Tweet has been viewed organically. This is a private metric, and
+   * requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return the number of times the Tweet has been viewed organically.
+   */
+  int getOrganicImpressionCount();
+
+  /**
+   * Get the number of likes the Tweet has received organically. This is a private metric, and
+   * requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return the number of likes the Tweet has received organically.
+   */
+  int getOrganicLikeCount();
+
+  /**
+   * Get the number of replies the Tweet has received organically. This is a private metric, and
+   * requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   *
+   * API v2 only!
+   * 
+   * @return the number of replies the Tweet has received organically.
+   */
+  int getOrganicReplyCount();
+
+  /**
+   * Get the number of times the Tweet has been Retweeted organically. This is a private metric, and
+   * requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return the number of times the Tweet has been Retweeted organically. This is a private metric,
+   *         and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   */
+  int getOrganicRetweetCount();
+
+  /**
+   * Get the number of times a user clicks on a URL link or URL preview card in a Tweet organically.
+   * This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context
+   * authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return the number of times a user clicks on a URL link or URL preview card in a Tweet
+   *         organically.
+   */
+  int getOrganicUrlLinkClicks();
+
+  /**
+   * Get the number of times a user clicks the following portions of a Tweet organically - display
+   * name, user name, profile picture. This is a private metric, and requires the use of OAuth 1.0a
+   * or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return the number of times a user clicks the following portions of a Tweet organically -
+   *         display name, user name, profile picture.
+   */
+  int getOrganicUserProfileClicks();
+
+  /**
+   * Number of times the Tweet has been viewed when that Tweet is being promoted. This is a private
+   * metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return
+   */
+  int getPromotedImpressionCount();
+
+  /**
+   * Number of Likes of this Tweet when that Tweet is being promoted. This is a private metric, and
+   * requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return
+   */
+  int getPromotedLikeCount();
+
+  /**
+   * Number of Replies to this Tweet when that Tweet is being promoted. This is a private metric,
+   * and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return
+   */
+  int getPromotedReplyCount();
+
+  /**
+   * Number of times this Tweet has been Retweeted when that Tweet is being promoted. This is a
+   * private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return
+   */
+  int getPromotedRetweetCount();
+
+  /**
+   * Number of times a user clicks on a URL link or URL preview card in a Tweet when it is being
+   * promoted. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User
+   * Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return
+   */
+  int getPromotedUrlLinkClicks();
+
+  /**
+   * Number of times a user clicks the following portions of a Tweet when it is being promoted -
+   * display name, user name, profile picture. This is a private metric, and requires the use of
+   * OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * 
+   * API v2 only!
+   * 
+   * @return
+   */
+  int getPromotedUserProfileClicks();
+
+  /**
    * Get the creation date of the tweet
    *
    * @return the tweet creation date

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV1.java
@@ -1,6 +1,7 @@
 package io.github.redouane59.twitter.dto.tweet;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.redouane59.twitter.dto.stream.StreamRules.StreamRule;
@@ -146,6 +147,110 @@ public class TweetV1 implements Tweet {
     return user.getId();
   }
 
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getImpressionCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getUrlLinkClicks() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getUserProfileClicks() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getOrganicImpressionCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getOrganicLikeCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getOrganicReplyCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getOrganicRetweetCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getOrganicUrlLinkClicks() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getOrganicUserProfileClicks() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getPromotedImpressionCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getPromotedLikeCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getPromotedReplyCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getPromotedRetweetCount() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getPromotedUrlLinkClicks() {
+    return 0;
+  }
+
+  /* Not available in API v1! */
+  @Override
+  @JsonIgnore
+  public int getPromotedUserProfileClicks() {
+    return 0;
+  }
 
   @Getter
   @Setter

--- a/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/tweet/TweetV2.java
@@ -189,6 +189,126 @@ public class TweetV2 implements Tweet {
   }
 
   @Override
+  public int getImpressionCount() {
+    if (data == null || data.getNonPublicMetrics() == null) {
+        return 0;
+    }
+    return data.getNonPublicMetrics().getImpressionCount();
+  }
+
+  @Override
+  public int getUrlLinkClicks() {
+    if (data == null || data.getNonPublicMetrics() == null) {
+        return 0;
+    }
+    return data.getNonPublicMetrics().getUrlLinkClicks();
+  }
+
+  @Override
+  public int getUserProfileClicks() {
+    if (data == null || data.getNonPublicMetrics() == null) {
+        return 0;
+    }
+    return data.getNonPublicMetrics().getUserProfileClicks();
+  }
+
+  @Override
+  public int getOrganicImpressionCount() {
+    if (data == null || data.getOrganicMetrics() == null) {
+        return 0;
+    }
+    return data.getOrganicMetrics().getImpressionCount();
+  }
+
+  @Override
+  public int getOrganicLikeCount() {
+    if (data == null || data.getOrganicMetrics() == null) {
+        return 0;
+    }
+    return data.getOrganicMetrics().getLikeCount();
+  }
+
+  @Override
+  public int getOrganicReplyCount() {
+    if (data == null || data.getOrganicMetrics() == null) {
+        return 0;
+    }
+    return data.getOrganicMetrics().getReplyCount();
+  }
+
+  @Override
+  public int getOrganicRetweetCount() {
+    if (data == null || data.getOrganicMetrics() == null) {
+        return 0;
+    }
+    return data.getOrganicMetrics().getRetweetCount();
+  }
+
+  @Override
+  public int getOrganicUrlLinkClicks() {
+    if (data == null || data.getOrganicMetrics() == null) {
+        return 0;
+    }
+    return data.getOrganicMetrics().getUrlLinkClicks();
+  }
+
+  @Override
+  public int getOrganicUserProfileClicks() {
+    if (data == null || data.getOrganicMetrics() == null) {
+        return 0;
+    }
+    return data.getOrganicMetrics().getUserProfileClicks();
+  }
+
+  @Override
+  public int getPromotedImpressionCount() {
+    if (data == null || data.getPromotedMetrics() == null) {
+        return 0;
+    }
+    return data.getPromotedMetrics().getImpressionCount();
+  }
+
+  @Override
+  public int getPromotedLikeCount() {
+    if (data == null || data.getPromotedMetrics() == null) {
+        return 0;
+    }
+    return data.getPromotedMetrics().getLikeCount();
+  }
+
+  @Override
+  public int getPromotedReplyCount() {
+    if (data == null || data.getPromotedMetrics() == null) {
+        return 0;
+    }
+    return data.getPromotedMetrics().getReplyCount();
+  }
+
+  @Override
+  public int getPromotedRetweetCount() {
+    if (data == null || data.getPromotedMetrics() == null) {
+        return 0;
+    }
+    return data.getPromotedMetrics().getRetweetCount();
+  }
+
+  @Override
+  public int getPromotedUrlLinkClicks() {
+    if (data == null || data.getPromotedMetrics() == null) {
+        return 0;
+    }
+    return data.getPromotedMetrics().getUrlLinkClicks();
+  }
+
+  @Override
+  public int getPromotedUserProfileClicks() {
+    if (data == null || data.getPromotedMetrics() == null) {
+        return 0;
+    }
+    return data.getPromotedMetrics().getUserProfileClicks();
+  }
+
+  @Override
   public String getInReplyToUserId() {
     if (data == null) {
       return null;
@@ -240,6 +360,26 @@ public class TweetV2 implements Tweet {
     return data.getReferencedTweets().get(0).getType();
   }
 
+  /** Returns whether the TweetPublicMetricsDTO object exists. Probably the field public_metrics was not requested if not. */
+  public boolean hasTweetPublicMetrics() {
+    return data!=null && data.hasPublicMetrics();
+  }
+
+  /** Returns whether the TweetNonPublicMetricsDTO object exists. Probably the field non_public_metrics was not requested if not. */
+  public boolean hasTweetNonPublicMetrics() {
+    return data!=null && data.hasNonPublicMetrics();
+  }
+  
+  /** Returns whether the TweetOrganicMetricsDTO object exists. Probably the field organic_metrics was not requested if not. */
+  public boolean hasTweetOrganicMetrics() {
+    return data!=null && data.hasOrganicMetrics();
+  }
+  
+  /** Returns whether the TweetPromotedMetricsDTO object exists. Probably the field promoted_metrics was not requested if not. */
+  public boolean hasTweetPromotedMetrics() {
+    return data!=null && data.hasPromotedMetrics();
+  }
+
   @Getter
   @Setter
   @Builder
@@ -262,6 +402,15 @@ public class TweetV2 implements Tweet {
     @JsonProperty("public_metrics")
     @JsonInclude(Include.NON_NULL)
     private TweetPublicMetricsDTO    publicMetrics;
+    @JsonProperty("non_public_metrics")
+    @JsonInclude(Include.NON_NULL)
+    private TweetNonPublicMetricsDTO nonPublicMetrics;
+    @JsonProperty("organic_metrics")
+    @JsonInclude(Include.NON_NULL)
+    private TweetOrganicMetricsDTO   organicMetrics;
+    @JsonProperty("promoted_metrics")
+    @JsonInclude(Include.NON_NULL)
+    private TweetPromotedMetricsDTO  promotedMetrics;
     @JsonProperty("possibly_sensitive")
     private boolean                  possiblySensitive;
     private String                   lang;
@@ -299,6 +448,115 @@ public class TweetV2 implements Tweet {
     @JsonIgnore
     public int getQuoteCount() {
       return publicMetrics.getQuoteCount();
+    }
+
+    /** Returns whether the TweetPublicMetricsDTO object exists. Probably the field public_metrics was not requested if not. */
+    public boolean hasPublicMetrics() {
+      return publicMetrics!=null;
+    }
+
+    @Override
+    @JsonIgnore
+    public int getImpressionCount() {
+      return nonPublicMetrics.getImpressionCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getUrlLinkClicks() {
+      return nonPublicMetrics.getUrlLinkClicks();
+    }
+    @Override
+    @JsonIgnore
+    public int getUserProfileClicks() {
+      return nonPublicMetrics.getUserProfileClicks();
+    }
+
+    /** Returns whether the TweetNonPublicMetricsDTO object exists. Probably the field non_public_metrics was not requested if not. */
+    public boolean hasNonPublicMetrics() {
+      return nonPublicMetrics!=null;
+    }
+
+    @Override
+    @JsonIgnore
+    public int getOrganicImpressionCount() {
+      return organicMetrics.getImpressionCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getOrganicLikeCount() {
+      return organicMetrics.getLikeCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getOrganicReplyCount() {
+      return organicMetrics.getReplyCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getOrganicRetweetCount() {
+      return organicMetrics.getRetweetCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getOrganicUrlLinkClicks() {
+      return organicMetrics.getUrlLinkClicks();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getOrganicUserProfileClicks() {
+      return organicMetrics.getUserProfileClicks();
+    }
+    
+    /** Returns whether the TweetOrganicMetricsDTO object exists. Probably the field organic_metrics was not requested if not. */
+    public boolean hasOrganicMetrics() {
+      return organicMetrics!=null;
+    }
+
+    @Override
+    @JsonIgnore
+    public int getPromotedImpressionCount() {
+      return promotedMetrics.getImpressionCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getPromotedLikeCount() {
+      return promotedMetrics.getLikeCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getPromotedReplyCount() {
+      return promotedMetrics.getReplyCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getPromotedRetweetCount() {
+      return promotedMetrics.getRetweetCount();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getPromotedUrlLinkClicks() {
+      return promotedMetrics.getUrlLinkClicks();
+    }
+
+    @Override
+    @JsonIgnore
+    public int getPromotedUserProfileClicks() {
+      return promotedMetrics.getUserProfileClicks();
+    }
+
+    /** Returns whether the TweetPromotedMetricsDTO object exists. Probably the field promoted_metrics was not requested if not. */
+    public boolean hasPromotedMetrics() {
+      return promotedMetrics!=null;
     }
 
     @Override
@@ -385,7 +643,6 @@ public class TweetV2 implements Tweet {
     private List<TweetV2.Place>         places;
   }
 
-
   @Getter
   @Setter
   public static class TweetPublicMetricsDTO {
@@ -400,6 +657,75 @@ public class TweetV2 implements Tweet {
     private int quoteCount;
   }
 
+  /** Non-public engagement metrics for the Tweet at the time of the request. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication.
+   * To return this field, add tweet.fields=non_public_metrics in the request's query parameter.*/
+  @Getter
+  @Setter
+  public static class TweetNonPublicMetricsDTO {
+
+    /** Number of times the Tweet has been viewed. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. **/
+    @JsonProperty("impression_count")
+    private int impressionCount;
+    /** Number of times a user clicks on a URL link or URL preview card in a Tweet. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. */
+    @JsonProperty("url_link_clicks")
+    private int urlLinkClicks;
+    /** Number of times a user clicks the following portions of a Tweet - display name, user name, profile picture. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. */
+    @JsonProperty("user_profile_clicks")
+    private int userProfileClicks;
+  }
+
+  /** Organic engagement metrics for the Tweet at the time of the request. Requires user context authentication. */
+  @Getter
+  @Setter
+  public static class TweetOrganicMetricsDTO {
+
+    /** Number of times the Tweet has been viewed organically. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. */
+    @JsonProperty("impression_count")
+    private int impressionCount;
+    /** Number of times a user clicks on a URL link or URL preview card in a Tweet organically. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. */
+    @JsonProperty("url_link_clicks")
+    private int urlLinkClicks;
+    /** Number of times a user clicks the following portions of a Tweet organically - display name, user name, profile picture. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. */
+    @JsonProperty("user_profile_clicks")
+    private int userProfileClicks;
+    /** Number of times the Tweet has been Retweeted organically. */
+    @JsonProperty("retweet_count")
+    private int retweetCount;
+    /** Number of replies the Tweet has received organically. */
+    @JsonProperty("reply_count")
+    private int replyCount;
+    /** Number of likes the Tweet has received organically. */
+    @JsonProperty("like_count")
+    private int likeCount;
+
+  }
+
+  /** Engagement metrics for the Tweet at the time of the request in a promoted context. Requires user context authentication. */
+  @Getter
+  @Setter
+  public static class TweetPromotedMetricsDTO {
+
+    /** Number of times the Tweet has been viewed when that Tweet is being promoted. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. */
+    @JsonProperty("impression_count")
+    private int impressionCount;
+    /** Number of times a user clicks on a URL link or URL preview card in a Tweet when it is being promoted. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. */
+    @JsonProperty("url_link_clicks")
+    private int urlLinkClicks;
+    /** Number of times a user clicks the following portions of a Tweet when it is being promoted - display name, user name, profile picture. This is a private metric, and requires the use of OAuth 1.0a or OAuth 2.0 User Context authentication. */
+    @JsonProperty("user_profile_clicks")
+    private int userProfileClicks;
+    /** Number of times this Tweet has been Retweeted when that Tweet is being promoted. */
+    @JsonProperty("retweet_count")
+    private int retweetCount;
+    /** Number of Replies to this Tweet when that Tweet is being promoted. */
+    @JsonProperty("reply_count")
+    private int replyCount;
+    /** Number of Likes of this Tweet when that Tweet is being promoted. */
+    @JsonProperty("like_count")
+    private int likeCount;
+
+  }
+  
   @Getter
   @Setter
   public static class EntitiesV2 implements Entities {

--- a/src/main/java/io/github/redouane59/twitter/dto/user/User.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/user/User.java
@@ -71,6 +71,20 @@ public interface User {
   int getTweetCount();
 
   /**
+   * Get the number of lists that include this user.
+   *
+   * @return number of lists that include this user.
+   */
+  public int getListedCount();
+
+  /** 
+   * Returns whether the users public metrics is included in the response.
+   * 
+   * @return whether users public metrics exists
+   */
+  public boolean hasPublicMetrics();
+
+  /**
    * Get the language of the user
    *
    * @return the user language

--- a/src/main/java/io/github/redouane59/twitter/dto/user/UserV1.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/user/UserV1.java
@@ -69,6 +69,19 @@ public class UserV1 implements User {
     return id.hashCode();
   }
 
+  /* This is not supported in API v1. */
+  @Override
+  public int getListedCount() {
+    LOGGER.debug("UnsupportedOperation");
+    return 0;
+  }
+
+  /* Returns whether the users public metrics is included in the response. This is always the case in API v1. */
+  @Override
+  public boolean hasPublicMetrics() {
+    return true;
+  }
+
   @Override
   public LocalDateTime getDateOfCreation() {
     return ConverterHelper.getDateFromTwitterString(dateOfCreation);

--- a/src/main/java/io/github/redouane59/twitter/dto/user/UserV2.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/user/UserV2.java
@@ -80,6 +80,18 @@ public class UserV2 implements User {
 
   @Override
   @JsonIgnore
+  public int getListedCount() {
+    return data.getPublicMetrics().getListedCount();
+  }
+
+  /* Returns whether the UserPublicMetrics object exists. Probably the field public_metrics was not requested if not. */
+  @Override
+  public boolean hasPublicMetrics() {
+    return data!=null && data.hasPublicMetrics();
+  }
+
+  @Override
+  @JsonIgnore
   public String getLang() {
     throw new UnsupportedOperationException();
   }
@@ -185,8 +197,18 @@ public class UserV2 implements User {
     }
 
     @Override
+    public int getListedCount() {
+      return publicMetrics.getListedCount();
+    }
+
+    @Override
     public int getTweetCount() {
       return publicMetrics.getTweetCount();
+    }
+
+    /* Returns whether the UserPublicMetrics object exists. Probably the field public_metrics was not requested if not. */
+    public boolean hasPublicMetrics() {
+      return publicMetrics!=null;
     }
 
     @Override

--- a/src/main/java/io/github/redouane59/twitter/helpers/AbstractRequestHelper.java
+++ b/src/main/java/io/github/redouane59/twitter/helpers/AbstractRequestHelper.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Optional;
 import javax.naming.LimitExceededException;
+import javax.naming.NoPermissionException;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
@@ -108,6 +109,8 @@ public abstract class AbstractRequestHelper {
       return makeRequest(request, false, classType); // We have already signed if it was requested
     } else if (response.getCode() < 200 || response.getCode() > 299) {
       logApiError(request.getVerb().name(), request.getUrl(), stringResponse, response.getCode());
+    } else if (stringResponse != null && stringResponse.startsWith("{\"errors\":")) {
+      throw new NoPermissionException(stringResponse);
     }
     result = convert(stringResponse, classType);
     return Optional.ofNullable(result);


### PR DESCRIPTION
Well. There are some design decisions that need to be discussed.

Tweet interface:
Obviously, API v1 and v2 are parting ways now even more. How to deal with that in the Interface `Tweet` and in the class `TweetV1` with the v2 only getters like `getImpressionCount()`? Now it returns 0. Should it better throw an exception? Return -1? Changing return type to return null?

Non-public:
What to return on non-public metrics in the DTOs, if requested in a public context? This metrics do not exist then and just returning 0 (which is happening) is misleading. To get around it, I added some `has`-methods (e.g. `hasOrganicMetrics()`). (For consistency reasons I even added them for public metrics in tweets and user.) For the single metrics I still would prefer returning `Integer null` instead of `int 0`.

Error management:
There seems to be a whole world, where twitter returns with http 200, but has only errors in the response. This happens on insufficient access rights for non-public data. Couldn't even find docs on that on twitter. I throw `NoPermissionException` on a certain condition now, but that is highly preliminarily. Further knowledge is still missing here what can happen.

Consumer key context:
To determine whether requesting with consumer key for user context or app-only bearer token, a var `useConsumerKey` in `RequestHelperV2` is used. But that would mean constructor explosion. So I did not add it to all constructors. I guess that is not final. Furthermore, it maybe would be nice to determine that per request, not per `TwitterClient`/`RequestHelperV2`.

Tests:
I skimmed over the tests but did not really had an idea.. I need some suggestions here what to do.