### PR TITLE
Add FilteredStreamRulePredicate.empty() to allow building of complex queries

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicate.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicate.java
@@ -14,7 +14,7 @@ public class FilteredStreamRulePredicate {
 
   private static FilteredStreamRulePredicate build(String one, String two, String operator) {
     FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    if (one.isEmpty()) {
+    if (one == null || one.isEmpty()) {
       p.predicate = operator + two;
     } else {
       p.predicate = one + " " + operator + two;
@@ -204,8 +204,12 @@ public class FilteredStreamRulePredicate {
     return this;
   }
 
+  public static FilteredStreamRulePredicate empty() {
+    return build("","","");
+  }
+
   public boolean isEmpty() {
-    return predicate == null || predicate.isEmpty();
+    return predicate == null;
   }
 
   @Override

--- a/src/test/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicateTest.java
+++ b/src/test/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicateTest.java
@@ -247,6 +247,17 @@ class FilteredStreamRulePredicateTest {
   }
 
   @Test
+  void testComplexQueries3() {
+    FilteredStreamRulePredicate p  = FilteredStreamRulePredicate.withExactPhrase("test");
+    FilteredStreamRulePredicate p2 = FilteredStreamRulePredicate.withBioName("test");
+    FilteredStreamRulePredicate p3 = FilteredStreamRulePredicate.withLanguage("de");
+    FilteredStreamRulePredicate p4 = FilteredStreamRulePredicate.withLanguage("en").negate();
+    assertEquals("(((\"test\" bio_name:test) OR lang:de) OR -(lang:en)) -(is:retweet)",
+            p.and(p2).capsule().or(p3).capsule().or(p4).capsule().and(FilteredStreamRulePredicate.isRetweet(FilteredStreamRulePredicate.empty()).negate()).toString());
+  }
+
+
+  @Test
   void testConjunctionOperatorsInvalid1() {
     FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
     Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {


### PR DESCRIPTION
# What does this PR do?

- Adds FilteredStreamRulePredicate.empty(), which is needed in case we have to deal with complex queries (boolean operators, negation and capsule)