### PR TITLE
feat: add DM user lookup endpoint V2

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
+++ b/src/main/java/io/github/redouane59/twitter/ITwitterClientV2.java
@@ -178,7 +178,7 @@ public interface ITwitterClientV2 {
    * Stops the filtered stream with the result of the startFilteredStream. It'll wait a maximum of timeout before giving up and returning false.  If
    * timeout isn't hit, it'll close the socket opened.
    *
-   * @param responseFuture Future<Response> given by startFilteredStream
+   * @param response Future<Response> given by startFilteredStream
    * @param timeout long How long to wait
    * @param unit TimeUnit Units for timeout
    */
@@ -187,7 +187,7 @@ public interface ITwitterClientV2 {
   /**
    * Stops the filtered stream with the result of the startFilteredStream. It'll close the socket opened.
    *
-   * @param responseFuture Future<Response> given by startFilteredStream
+   * @param response Future<Response> given by startFilteredStream
    */
   boolean stopFilteredStream(Future<Response> response);
 
@@ -668,11 +668,23 @@ public interface ITwitterClientV2 {
    * Returns a list of Direct Messages within a conversation specified in the dm_conversation_id path parameter calling
    * https://api.twitter.com/2/dm_conversations/:dm_conversation_id/dm_events. Messages are returned in reverse chronological order.
    */
-  DirectMessage getDirectMessages(String conversationId);
+  DirectMessage getDirectMessagesByConversation(String conversationId);
 
   /**
    * Returns a list of Direct Messages within a conversation specified in the dm_conversation_id path parameter calling
    * https://api.twitter.com/2/dm_conversations/:dm_conversation_id/dm_events. Messages are returned in reverse chronological order.
    */
-  DirectMessage getDirectMessages(String conversationId, AdditionalParameters additionalParameters);
+  DirectMessage getDirectMessagesByConversation(String conversationId, AdditionalParameters additionalParameters);
+
+  /**
+   * Returns a list of Direct Messages (DM) events within a 1-1 conversation with the user specified in the participant_id path parameter calling
+   * https://api.twitter.com/2/dm_conversations/with/:participant_id/dm_events. Messages are returned in reverse chronological order.
+   */
+  DirectMessage getDirectMessagesByUser(String participantId);
+
+  /**
+   * Returns a list of Direct Messages (DM) events within a 1-1 conversation with the user specified in the participant_id path parameter calling
+   * https://api.twitter.com/2/dm_conversations/with/:participant_id/dm_events. Messages are returned in reverse chronological order.
+   */
+  DirectMessage getDirectMessagesByUser(String participantId, AdditionalParameters additionalParameters);
 }

--- a/src/main/java/io/github/redouane59/twitter/TwitterClient.java
+++ b/src/main/java/io/github/redouane59/twitter/TwitterClient.java
@@ -827,12 +827,12 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
   }
 
   @Override
-  public DirectMessage getDirectMessages(String conversationId) {
-    return getDirectMessages(conversationId, AdditionalParameters.builder().maxResults(100).build());
+  public DirectMessage getDirectMessagesByConversation(String conversationId) {
+    return getDirectMessagesByConversation(conversationId, AdditionalParameters.builder().maxResults(100).build());
   }
 
   @Override
-  public DirectMessage getDirectMessages(String conversationId, final AdditionalParameters additionalParameters) {
+  public DirectMessage getDirectMessagesByConversation(String conversationId, final AdditionalParameters additionalParameters) {
     String              url        = getUrlHelper().getDmLookupUrl(conversationId);
     Map<String, String> parameters = additionalParameters.getMapFromParameters();
     parameters.put(DM_FIELDS, ALL_DM_FIELDS);
@@ -841,6 +841,24 @@ public class TwitterClient implements ITwitterClientV1, ITwitterClientV2, ITwitt
     parameters.put(USER_FIELDS, ALL_USER_FIELDS);
     parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
     return getRequestHelperV1().getRequestWithParameters(url, parameters, DirectMessage.class).orElseThrow(NoSuchElementException::new);
+  }
+
+  @Override
+  public DirectMessage getDirectMessagesByUser(final String participantId) {
+    return getDirectMessagesByUser(participantId, AdditionalParameters.builder().maxResults(100).build());
+  }
+
+  @Override
+  public DirectMessage getDirectMessagesByUser(final String participantId, final AdditionalParameters additionalParameters) {
+    String              url        = getUrlHelper().getDmUserLookupUrl(participantId);
+    Map<String, String> parameters = additionalParameters.getMapFromParameters();
+    parameters.put(DM_FIELDS, ALL_DM_FIELDS);
+    parameters.put(EXPANSION, ALL_DM_EXPANSIONS);
+    parameters.put(TWEET_FIELDS, ALL_TWEET_FIELDS);
+    parameters.put(USER_FIELDS, ALL_USER_FIELDS);
+    parameters.put(MEDIA_FIELD, ALL_MEDIA_FIELDS);
+    return getRequestHelperV1().getRequestWithParameters(url, parameters, DirectMessage.class).orElseThrow(NoSuchElementException::new);
+
   }
 
 

--- a/src/main/java/io/github/redouane59/twitter/helpers/URLHelper.java
+++ b/src/main/java/io/github/redouane59/twitter/helpers/URLHelper.java
@@ -100,6 +100,7 @@ public class URLHelper {
   private final String unfollowListUrl     = "https://api.twitter.com/2/users/:id/followed_lists/:list_id";
   private final String ownedListUrl        = "https://api.twitter.com/2/users/:id/owned_lists";
   private final String dmLookupUrl         = "https://api.twitter.com/2/dm_conversations/:dm_conversation_id/dm_events";
+  private final String dmUserLookupUrl     = "https://api.twitter.com/2/dm_conversations/with/:participant_id/dm_events";
 
   public String getSearchTweet30DaysUrl(String envName) {
     return ROOT_URL_V1 + TWEETS + SEARCH + THIRTY_DAYS + "/" + envName + JSON;
@@ -316,5 +317,9 @@ public class URLHelper {
 
   public String getDmLookupUrl(String conversationId) {
     return dmLookupUrl.replace(":dm_conversation_id", conversationId);
+  }
+
+  public String getDmUserLookupUrl(String conversationId) {
+    return dmUserLookupUrl.replace(":participant_id", conversationId);
   }
 }

--- a/src/test/java/io/github/redouane59/twitter/nrt/ITwitterClientV2AuthenticatedTest.java
+++ b/src/test/java/io/github/redouane59/twitter/nrt/ITwitterClientV2AuthenticatedTest.java
@@ -368,9 +368,9 @@ public class ITwitterClientV2AuthenticatedTest {
 
   @Test
   @Disabled
-  public void testGetDirectMessages() {
+  public void testGetDirectMessagesByConversation() {
     String        conversationId = "108209516-1120050519182016513";
-    DirectMessage dmEvents       = twitterClient.getDirectMessages(conversationId);
+    DirectMessage dmEvents       = twitterClient.getDirectMessagesByConversation(conversationId);
     assertNotNull(dmEvents);
     assertNotNull(dmEvents.getData());
     assertTrue(dmEvents.getData().size() > 0);
@@ -383,7 +383,28 @@ public class ITwitterClientV2AuthenticatedTest {
     assertNotNull(dmEvents.getIncludes());
     assertNotNull(dmEvents.getIncludes().getUsers());
     assertTrue(dmEvents.getMeta().getResultCount() > 0);
-    dmEvents = twitterClient.getDirectMessages(conversationId, AdditionalParameters.builder().maxResults(2).build());
+    dmEvents = twitterClient.getDirectMessagesByConversation(conversationId, AdditionalParameters.builder().maxResults(2).build());
+    assertTrue(dmEvents.getData().size() < 3);
+  }
+
+  @Test
+  @Disabled
+  public void testGetDirectMessagesByUser() {
+    String        userId   = "108209516";
+    DirectMessage dmEvents = twitterClient.getDirectMessagesByUser(userId);
+    assertNotNull(dmEvents);
+    assertNotNull(dmEvents.getData());
+    assertTrue(dmEvents.getData().size() > 0);
+    assertNotNull(dmEvents.getData().get(0).getId());
+    assertNotNull(dmEvents.getData().get(0).getText());
+    assertNotNull(dmEvents.getData().get(0).getEventType());
+    assertNotNull(dmEvents.getData().get(0).getSenderId());
+    assertNotNull(dmEvents.getData().get(0).getDmConversationId());
+    assertNotNull(dmEvents.getData().get(0).getCreatedAt());
+    assertNotNull(dmEvents.getIncludes());
+    assertNotNull(dmEvents.getIncludes().getUsers());
+    assertTrue(dmEvents.getMeta().getResultCount() > 0);
+    dmEvents = twitterClient.getDirectMessagesByUser(userId, AdditionalParameters.builder().maxResults(2).build());
     assertTrue(dmEvents.getData().size() < 3);
   }
 


### PR DESCRIPTION
See https://developer.twitter.com/en/docs/twitter-api/direct-messages/lookup/api-reference/get-dm_conversations-with-participant_id-dm_events