### PR TITLE
Empty predicate

### DIFF
--- a/src/main/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicate.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicate.java
@@ -12,6 +12,10 @@ public class FilteredStreamRulePredicate {
   FilteredStreamRulePredicate() {
   }
 
+  private FilteredStreamRulePredicate(String predicate) {
+    this.predicate = predicate;
+  }
+
   private static FilteredStreamRulePredicate build(String one, String two, String operator) {
     FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
     if (one == null || one.isEmpty()) {
@@ -27,194 +31,196 @@ public class FilteredStreamRulePredicate {
   }
 
   public static FilteredStreamRulePredicate withEmoji(String emoji) {
-    return build("", emoji, "");
+    return new FilteredStreamRulePredicate(emoji);
   }
 
   public static FilteredStreamRulePredicate withExactPhrase(String phrase) {
-    return build("", "\"" + phrase + "\"", "");
+    return new FilteredStreamRulePredicate(quote(phrase));
   }
 
   public static FilteredStreamRulePredicate withHashtag(String hashtag) {
-    return build("", hashtag.startsWith("#") ? hashtag : "#" + hashtag, "");
+    String predicate = hashtag.startsWith("#") ? hashtag : "#" + hashtag;
+    return new FilteredStreamRulePredicate(predicate);
   }
 
   public static FilteredStreamRulePredicate withMention(String mention) {
-    return build("", mention.startsWith("@") ? mention : "@" + mention, "");
+    String predicate = mention.startsWith("@") ? mention : "@" + mention;
+    return new FilteredStreamRulePredicate(predicate);
   }
 
   public static FilteredStreamRulePredicate withCashtag(String cashtag) {
-    return build("", cashtag.startsWith("$") ? cashtag : "$" + cashtag, "");
+    String predicate = cashtag.startsWith("$") ? cashtag : "$" + cashtag;
+    return new FilteredStreamRulePredicate(predicate);
   }
 
   public static FilteredStreamRulePredicate withUser(String user) {
-    return build("", user, "from:");
+    return new FilteredStreamRulePredicate("from:" + user);
   }
 
   public static FilteredStreamRulePredicate withReplyTo(String user) {
-    return build("", user, "to:");
+    return new FilteredStreamRulePredicate("to:" + user);
   }
 
   public static FilteredStreamRulePredicate withUrl(String url) {
-    return build("", withExactPhrase(url).toString(), "url:");
+    return new FilteredStreamRulePredicate("url:" + quote(url));
   }
 
   public static FilteredStreamRulePredicate withRetweetsOf(String user) {
-    return build("", user, "retweets_of:");
+    return new FilteredStreamRulePredicate("retweets_of:" + user);
   }
 
   public static FilteredStreamRulePredicate withContext(String context) {
-    return build("", context, "context:");
+    return new FilteredStreamRulePredicate("context:" + context);
   }
 
   public static FilteredStreamRulePredicate withEntity(String entity) {
-    return build("", withExactPhrase(entity).toString(), "entity:");
+    return new FilteredStreamRulePredicate("entity:" + quote(entity));
   }
 
   public static FilteredStreamRulePredicate withConversationId(String conversationId) {
-    return build("", conversationId, "conversation_id:");
+    return new FilteredStreamRulePredicate("conversation_id:" + conversationId);
   }
 
   public static FilteredStreamRulePredicate withBio(String bio) {
-    return build("", bio, "bio:");
+    return new FilteredStreamRulePredicate("bio:" + bio);
   }
 
   public static FilteredStreamRulePredicate withBioName(String bioName) {
-    return build("", bioName, "bio_name:");
+    return new FilteredStreamRulePredicate("bio_name:" + bioName);
   }
 
   public static FilteredStreamRulePredicate withBioLocation(String bioLocation) {
-    return build("", bioLocation, "bio_location:");
+    return new FilteredStreamRulePredicate("bio_location:" + bioLocation);
   }
 
   public static FilteredStreamRulePredicate withPlace(String place) {
-    return build("", place, "place:");
+    return new FilteredStreamRulePredicate("place:" + place);
   }
 
   public static FilteredStreamRulePredicate withPlaceCountry(String alpha2IsoCode) {
-    return build("", alpha2IsoCode, "place_country:");
+    return new FilteredStreamRulePredicate("place_country:" + alpha2IsoCode);
   }
 
   public static FilteredStreamRulePredicate withPointRadius(double longitude, double latitude, String radius) {
     //mi or km
-    return build("", "[" + longitude + " " + latitude + " " + radius + "]", "point_radius:");
+    String pointRadius = "[" + longitude + " " + latitude + " " + radius + "]";
+    return new FilteredStreamRulePredicate("point_radius:" + pointRadius);
   }
 
   public static FilteredStreamRulePredicate withBoundingBox(double westLongitude, double southLatitude, double eastLongitude, double northLatitude) {
     //mi or km
-    return build("", "[" + westLongitude + " " + southLatitude + " " + eastLongitude + " " + northLatitude + "]", "bounding_box:");
+    String boundingBox = "[" + westLongitude + " " + southLatitude + " " + eastLongitude + " " + northLatitude + "]";
+    return new FilteredStreamRulePredicate("bounding_box:" + boundingBox);
   }
 
   public static FilteredStreamRulePredicate withLanguage(String language) {
-    return build("", language, "lang:");
+    return new FilteredStreamRulePredicate("lang:" + language);
   }
 
-  public static FilteredStreamRulePredicate isRetweet(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "is:retweet");
+  public static FilteredStreamRulePredicate isRetweet() {
+    return new FilteredStreamRulePredicate("is:retweet");
   }
 
-  public static FilteredStreamRulePredicate isReply(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "is:reply");
+  public static FilteredStreamRulePredicate isReply() {
+    return new FilteredStreamRulePredicate("is:reply");
   }
 
-  public static FilteredStreamRulePredicate isQuote(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "is:quote");
+  public static FilteredStreamRulePredicate isQuote() {
+    return new FilteredStreamRulePredicate("is:quote");
   }
 
-  public static FilteredStreamRulePredicate isVerified(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "is:verified");
+  public static FilteredStreamRulePredicate isVerified() {
+    return new FilteredStreamRulePredicate("is:verified");
   }
 
-  public static FilteredStreamRulePredicate isNullcast(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "-is:nullcast");
+  public static FilteredStreamRulePredicate isNullcast() {
+    return new FilteredStreamRulePredicate("-is:nullcast");
   }
 
-  public static FilteredStreamRulePredicate hasHashtags(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "has:hashtags");
+  public static FilteredStreamRulePredicate hasHashtags() {
+    return new FilteredStreamRulePredicate("has:hashtags");
   }
 
-  public static FilteredStreamRulePredicate hasCashtags(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "has:cashtags");
+  public static FilteredStreamRulePredicate hasCashtags() {
+    return new FilteredStreamRulePredicate("has:cashtags");
   }
 
-  public static FilteredStreamRulePredicate hasLinks(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "has:links");
+  public static FilteredStreamRulePredicate hasLinks() {
+    return new FilteredStreamRulePredicate("has:links");
   }
 
-  public static FilteredStreamRulePredicate hasMentions(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "has:mentions");
+  public static FilteredStreamRulePredicate hasMentions() {
+    return new FilteredStreamRulePredicate("has:mentions");
   }
 
-  public static FilteredStreamRulePredicate hasMedia(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "has:media");
+  public static FilteredStreamRulePredicate hasMedia() {
+    return new FilteredStreamRulePredicate("has:media");
   }
 
-  public static FilteredStreamRulePredicate hasImages(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "has:images");
+  public static FilteredStreamRulePredicate hasImages() {
+    return new FilteredStreamRulePredicate("has:images");
   }
 
-  public static FilteredStreamRulePredicate hasVideos(FilteredStreamRulePredicate predicate) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), "", "has:videos");
+  public static FilteredStreamRulePredicate hasVideos() {
+    return new FilteredStreamRulePredicate("has:videos");
   }
 
-  public static FilteredStreamRulePredicate hasGeo(FilteredStreamRulePredicate predicate, String geo) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), " " + geo, "has:geo");
+  public static FilteredStreamRulePredicate hasGeo(String geo) {
+    return new FilteredStreamRulePredicate("has:geo " + geo);
   }
 
-  public static FilteredStreamRulePredicate doSampling(FilteredStreamRulePredicate predicate, int sampleSize) {
-    checkConjunction(predicate);
-    return build(predicate.toString(), Integer.toString(sampleSize), "sample:");
-  }
-
-  private static void checkConjunction(FilteredStreamRulePredicate predicate) {
-    if (predicate == null || predicate.isEmpty()) {
-      throw new RuleBuilderException("Given operator can only be used in an conjunction");
-    }
+  public static FilteredStreamRulePredicate doSampling(int sampleSize) {
+    return new FilteredStreamRulePredicate("sample:" + sampleSize);
   }
 
   public FilteredStreamRulePredicate negate() {
+    if (predicate == null) {
+      throw new RuleBuilderException("Cannot negate empty predicate");
+    }
     predicate = "-" + capsule();
     return this;
   }
 
   public FilteredStreamRulePredicate capsule() {
-    predicate = "(" + predicate + ")";
+    if (predicate != null) {
+      predicate = "(" + predicate + ")";
+    }
     return this;
   }
 
   public FilteredStreamRulePredicate or(FilteredStreamRulePredicate other) {
-    predicate += " OR " + other.predicate;
+    applyOperator(" OR ", other);
     return this;
   }
 
   public FilteredStreamRulePredicate and(FilteredStreamRulePredicate other) {
-    predicate += " " + other.predicate;
+    applyOperator(" ", other);
     return this;
   }
 
   public static FilteredStreamRulePredicate empty() {
-    return build("", "", "");
+    return new FilteredStreamRulePredicate(null);
   }
 
   public boolean isEmpty() {
     return predicate == null;
   }
 
+  private void applyOperator(String operator, FilteredStreamRulePredicate right) {
+    if (this.predicate == null) {
+      this.predicate = right.predicate;
+    } else if (right != null && !right.isEmpty()) {
+      this.predicate = this.predicate + operator + right.predicate;
+    }
+  }
+
+  private static String quote(String phrase) {
+    return "\"" + phrase + "\"";
+  }
+
   @Override
   public String toString() {
-    return predicate;
+    return (predicate != null ? predicate : "");
   }
 
   public static class RuleBuilderException extends RuntimeException {

--- a/src/main/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicate.java
+++ b/src/main/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicate.java
@@ -205,7 +205,7 @@ public class FilteredStreamRulePredicate {
   }
 
   public static FilteredStreamRulePredicate empty() {
-    return build("","","");
+    return build("", "", "");
   }
 
   public boolean isEmpty() {

--- a/src/test/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicateTest.java
+++ b/src/test/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicateTest.java
@@ -253,7 +253,14 @@ class FilteredStreamRulePredicateTest {
     FilteredStreamRulePredicate p3 = FilteredStreamRulePredicate.withLanguage("de");
     FilteredStreamRulePredicate p4 = FilteredStreamRulePredicate.withLanguage("en").negate();
     assertEquals("(((\"test\" bio_name:test) OR lang:de) OR -(lang:en)) -(is:retweet)",
-            p.and(p2).capsule().or(p3).capsule().or(p4).capsule().and(FilteredStreamRulePredicate.isRetweet(FilteredStreamRulePredicate.empty()).negate()).toString());
+                 p.and(p2)
+                  .capsule()
+                  .or(p3)
+                  .capsule()
+                  .or(p4)
+                  .capsule()
+                  .and(FilteredStreamRulePredicate.isRetweet(FilteredStreamRulePredicate.empty()).negate())
+                  .toString());
   }
 
 

--- a/src/test/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicateTest.java
+++ b/src/test/java/io/github/redouane59/twitter/dto/rules/FilteredStreamRulePredicateTest.java
@@ -1,11 +1,20 @@
 package io.github.redouane59.twitter.dto.rules;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Assertions;
+import io.github.redouane59.twitter.dto.rules.FilteredStreamRulePredicate.RuleBuilderException;
 import org.junit.jupiter.api.Test;
 
 class FilteredStreamRulePredicateTest {
+
+  @Test
+  void testEmpty() {
+    final FilteredStreamRulePredicate p = FilteredStreamRulePredicate.empty();
+    assertEquals("", p.toString());
+    assertTrue(p.isEmpty());
+  }
 
   @Test
   void testExactPhrase() {
@@ -152,79 +161,109 @@ class FilteredStreamRulePredicateTest {
   }
 
   @Test
+  void testNegateOnEmptyPredicate() {
+    final FilteredStreamRulePredicate p = FilteredStreamRulePredicate.empty();
+    assertThrows(RuleBuilderException.class, p::negate);
+  }
+
+  @Test
   void testCapsule() {
     assertEquals("(point_radius:[2.355128 48.861118 16km])",
                  FilteredStreamRulePredicate.withPointRadius(2.355128, 48.861118, "16km").capsule().toString());
   }
 
   @Test
+  void testCapsuleOnEmptyPredicate() {
+    final FilteredStreamRulePredicate p = FilteredStreamRulePredicate.empty().capsule();
+    assertTrue(p.isEmpty());
+  }
+
+  @Test
   void testIsRetweet() {
-    assertEquals("test is:retweet", FilteredStreamRulePredicate.isRetweet(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test is:retweet", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.isRetweet()).toString());
   }
 
   @Test
   void testIsReply() {
-    assertEquals("test is:reply", FilteredStreamRulePredicate.isReply(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test is:reply", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.isReply()).toString());
   }
 
   @Test
   void testIsQuote() {
-    assertEquals("test is:quote", FilteredStreamRulePredicate.isQuote(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test is:quote", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.isQuote()).toString());
   }
 
   @Test
   void testIsVerified() {
-    assertEquals("test is:verified", FilteredStreamRulePredicate.isVerified(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test is:verified", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.isVerified()).toString());
   }
 
   @Test
   void testIsNullcast() {
-    assertEquals("test -is:nullcast", FilteredStreamRulePredicate.isNullcast(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test -is:nullcast", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.isNullcast()).toString());
   }
 
   @Test
   void testHasHashtags() {
-    assertEquals("test has:hashtags", FilteredStreamRulePredicate.hasHashtags(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test has:hashtags", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.hasHashtags()).toString());
   }
 
   @Test
   void testHasCashtags() {
-    assertEquals("test has:cashtags", FilteredStreamRulePredicate.hasCashtags(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test has:cashtags", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.hasCashtags()).toString());
   }
 
   @Test
   void testHasLinks() {
-    assertEquals("test has:links", FilteredStreamRulePredicate.hasLinks(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test has:links", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.hasLinks()).toString());
   }
 
   @Test
   void testHasMentions() {
-    assertEquals("test has:mentions", FilteredStreamRulePredicate.hasMentions(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test has:mentions", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.hasMentions()).toString());
   }
 
   @Test
   void testHasMedia() {
-    assertEquals("test has:media", FilteredStreamRulePredicate.hasMedia(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test has:media", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.hasMedia()).toString());
   }
 
   @Test
   void testHasImages() {
-    assertEquals("test has:images", FilteredStreamRulePredicate.hasImages(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test has:images", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.hasImages()).toString());
   }
 
   @Test
   void testHasVideos() {
-    assertEquals("test has:videos", FilteredStreamRulePredicate.hasVideos(FilteredStreamRulePredicate.withKeyword("test")).toString());
+    assertEquals("test has:videos", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.hasVideos()).toString());
   }
 
   @Test
   void testHasGeo() {
-    assertEquals("test has:geo bakery", FilteredStreamRulePredicate.hasGeo(FilteredStreamRulePredicate.withKeyword("test"), "bakery").toString());
+    assertEquals("test has:geo bakery", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.hasGeo("bakery")).toString());
   }
 
   @Test
   void testSample() {
-    assertEquals("test sample:15", FilteredStreamRulePredicate.doSampling(FilteredStreamRulePredicate.withKeyword("test"), 15).toString());
+    assertEquals("test sample:15", FilteredStreamRulePredicate.withKeyword("test").and(FilteredStreamRulePredicate.doSampling(15)).toString());
+  }
+
+  @Test
+  void testOrWithLeftEmptyPredicate() {
+    final FilteredStreamRulePredicate p = FilteredStreamRulePredicate.empty();
+    assertEquals("lang:de", p.or(FilteredStreamRulePredicate.withLanguage("de")).toString());
+  }
+
+  @Test
+  void testOrWithRightEmptyPredicate() {
+    final FilteredStreamRulePredicate p = FilteredStreamRulePredicate.withLanguage("de");
+    assertEquals("lang:de", p.or(FilteredStreamRulePredicate.empty()).toString());
+  }
+
+  @Test
+  void testAndWithLeftEmptyPredicate() {
+    final FilteredStreamRulePredicate p = FilteredStreamRulePredicate.withLanguage("de");
+    assertEquals("lang:de", p.and(FilteredStreamRulePredicate.empty()).toString());
   }
 
   @Test
@@ -243,7 +282,7 @@ class FilteredStreamRulePredicateTest {
     FilteredStreamRulePredicate p3 = FilteredStreamRulePredicate.withLanguage("de");
     FilteredStreamRulePredicate p4 = FilteredStreamRulePredicate.withLanguage("en").negate();
     assertEquals("((\"test\" bio_name:test) OR lang:de) OR -(lang:en) sample:15",
-                 FilteredStreamRulePredicate.doSampling(p.and(p2).capsule().or(p3).capsule().or(p4), 15).toString());
+                 p.and(p2).capsule().or(p3).capsule().or(p4).and(FilteredStreamRulePredicate.doSampling(15)).toString());
   }
 
   @Test
@@ -259,163 +298,8 @@ class FilteredStreamRulePredicateTest {
                   .capsule()
                   .or(p4)
                   .capsule()
-                  .and(FilteredStreamRulePredicate.isRetweet(FilteredStreamRulePredicate.empty()).negate())
+                  .and(FilteredStreamRulePredicate.isRetweet().negate())
                   .toString());
   }
 
-
-  @Test
-  void testConjunctionOperatorsInvalid1() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isReply(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isReply(p);
-    });
-
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid2() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isRetweet(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isRetweet(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid3() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isQuote(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isQuote(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid4() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isVerified(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isVerified(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid5() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isNullcast(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.isNullcast(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid6() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasHashtags(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasHashtags(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid7() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasCashtags(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasCashtags(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid8() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasLinks(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasLinks(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid9() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasMentions(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasMentions(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid10() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasMedia(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasMedia(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid11() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasImages(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasImages(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid12() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasVideos(null);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasVideos(p);
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid13() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasGeo(null, "test");
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.hasGeo(p, "test");
-    });
-  }
-
-  @Test
-  void testConjunctionOperatorsInvalid14() {
-    FilteredStreamRulePredicate p = new FilteredStreamRulePredicate();
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.doSampling(null, 15);
-    });
-    Assertions.assertThrows(FilteredStreamRulePredicate.RuleBuilderException.class, () -> {
-      FilteredStreamRulePredicate.doSampling(p, 15);
-    });
-  }
 }


### PR DESCRIPTION
This handles empty predicates properly if used with an `or` or `and` operator.

While using certain predicates without any additional logic with the Twitter API is forbidden, the current API does not correctly prevent that as it is a `static` method. A better way would be to make that an operator of a non-empty predicate but there isn't an easy way to do that. This commit removes this limitation.

See #433 