### PR TITLE
provided scope for sonar-plugin cause not needed in production package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
       <groupId>org.codehaus.sonar</groupId>
       <type>maven-plugin</type>
       <version>1.13</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
this dependency is old and has many vulnerable dependencies.
with scope provided its not delivered in production.
its only used in a maven command by the pipeline.

alternative: update to newest plugin: https://mvnrepository.com/artifact/org.sonarsource.scanner.maven/sonar-maven-plugin